### PR TITLE
feat(contract): cancel mission state

### DIFF
--- a/quid-contract/contracts/quid-store/src/error.rs
+++ b/quid-contract/contracts/quid-store/src/error.rs
@@ -10,4 +10,5 @@ pub enum QuidError {
     InsufficientFunds = 5,
     NotAuthorized = 6,
     NegativeReward = 7,
+    InvalidState = 8,
 }


### PR DESCRIPTION
## Summary

- Implements `cancel_mission(env: Env, id: u64) -> Result<(), QuidError>` in the Quid Store contract
- Adds `InvalidState = 8` error variant to `QuidError` for the state validation constraint
- A mission cannot be cancelled if its status is already `Completed`; returns `QuidError::InvalidState` in that case
- Owner authentication is enforced via `mission.owner.require_auth()`

## Changes

- **`error.rs`**: Added `InvalidState = 8` error variant
- **`lib.rs`**: Implemented `cancel_mission` following the steps in the issue (load → auth → validate → update → save → return)
- **`test.rs`**: Added 4 tests covering all acceptance criteria

## Test plan

- [x] `test_cancel_mission_success` — status updates to `Cancelled` from `Created`
- [x] `test_cancel_mission_fails_if_completed` — panics with `Error(Contract, #8)` when already `Completed`
- [x] `test_cancel_mission_from_started_status` — can cancel from `Started` status
- [x] `test_cancel_mission_not_found` — panics with `Error(Contract, #1)` for unknown mission IDs
- [x] All 18 tests pass (`cargo test`)
- [x] WASM build succeeds (`cargo build --target wasm32-unknown-unknown --release`)

Closes #37
