### PR TITLE
feat(backend): include mission owner data and counts

### DIFF
--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { MissionsService } from './missions.service';
 import { ListMissionsQueryDto } from './dto/list-missions-query.dto';
 
@@ -9,5 +9,10 @@ export class MissionsController {
   @Get()
   list(@Query() query: ListMissionsQueryDto): Promise<unknown> {
     return this.missionsService.listPublicMissions(query);
+  }
+
+  @Get(':id')
+  detail(@Param('id') id: string): Promise<unknown> {
+    return this.missionsService.getMission(id);
   }
 }

--- a/backend/src/missions/missions.service.spec.ts
+++ b/backend/src/missions/missions.service.spec.ts
@@ -1,75 +1,132 @@
+import { NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { MissionsService } from './missions.service';
 import { MissionListSort } from './dto/list-missions-query.dto';
 import { MissionStatus } from '@prisma/client';
 
+const listInclude = {
+  owner: { select: { address: true, displayName: true } },
+  _count: { select: { submissions: true } },
+};
+
+const detailInclude = {
+  owner: { select: { address: true, displayName: true, email: true } },
+  _count: { select: { submissions: true } },
+};
+
 describe('MissionsService', () => {
   let service: MissionsService;
-  let prisma: { mission: { findMany: jest.Mock } };
+  let prisma: { mission: { findMany: jest.Mock; findUnique: jest.Mock } };
 
   beforeEach(() => {
     prisma = {
       mission: {
         findMany: jest.fn(),
+        findUnique: jest.fn(),
       },
     };
 
     service = new MissionsService(prisma as unknown as PrismaService);
   });
 
-  it('applies filters, newest sort, and limit to the public mission query', async () => {
-    prisma.mission.findMany.mockResolvedValue([]);
+  describe('listPublicMissions', () => {
+    it('applies filters, newest sort, and limit to the public mission query', async () => {
+      prisma.mission.findMany.mockResolvedValue([]);
 
-    await service.listPublicMissions({
-      status: 'OPEN',
-      sort: MissionListSort.NEWEST,
-      limit: 5,
+      await service.listPublicMissions({
+        status: 'OPEN',
+        sort: MissionListSort.NEWEST,
+        limit: 5,
+      });
+
+      expect(prisma.mission.findMany).toHaveBeenCalledWith({
+        where: { status: MissionStatus.OPEN },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+        include: listInclude,
+      });
     });
 
-    expect(prisma.mission.findMany).toHaveBeenCalledWith({
-      where: { status: MissionStatus.OPEN },
-      orderBy: { createdAt: 'desc' },
-      take: 5,
+    it('normalizes lowercase status values before querying Prisma', async () => {
+      prisma.mission.findMany.mockResolvedValue([]);
+
+      await service.listPublicMissions({ status: 'open' });
+
+      expect(prisma.mission.findMany).toHaveBeenCalledWith({
+        where: { status: MissionStatus.OPEN },
+        orderBy: { createdAt: 'desc' },
+        take: undefined,
+        include: listInclude,
+      });
+    });
+
+    it('uses default newest ordering when no query params are provided', async () => {
+      prisma.mission.findMany.mockResolvedValue([]);
+
+      await service.listPublicMissions({});
+
+      expect(prisma.mission.findMany).toHaveBeenCalledWith({
+        where: {},
+        orderBy: { createdAt: 'desc' },
+        take: undefined,
+        include: listInclude,
+      });
+    });
+
+    it('supports oldest sorting for public mission discovery', async () => {
+      prisma.mission.findMany.mockResolvedValue([]);
+
+      await service.listPublicMissions({ sort: MissionListSort.OLDEST });
+
+      expect(prisma.mission.findMany).toHaveBeenCalledWith({
+        where: {},
+        orderBy: { createdAt: 'asc' },
+        take: undefined,
+        include: listInclude,
+      });
+    });
+
+    it('includes owner address, displayName, and submission count in list results', async () => {
+      const mockMission = {
+        id: 'mission-1',
+        owner: { address: '0xabc', displayName: 'Alice' },
+        _count: { submissions: 3 },
+      };
+      prisma.mission.findMany.mockResolvedValue([mockMission]);
+
+      const result = await service.listPublicMissions({}) as typeof mockMission[];
+
+      expect(result[0].owner.address).toBe('0xabc');
+      expect(result[0].owner.displayName).toBe('Alice');
+      expect(result[0]._count.submissions).toBe(3);
     });
   });
 
-  it('normalizes lowercase status values before querying Prisma', async () => {
-    prisma.mission.findMany.mockResolvedValue([]);
+  describe('getMission', () => {
+    it('returns a mission with owner address, displayName, email, and submission count', async () => {
+      const mockMission = {
+        id: 'mission-1',
+        owner: { address: '0xabc', displayName: 'Alice', email: 'alice@example.com' },
+        _count: { submissions: 5 },
+      };
+      prisma.mission.findUnique.mockResolvedValue(mockMission);
 
-    await service.listPublicMissions({
-      status: 'open',
+      const result = await service.getMission('mission-1') as typeof mockMission;
+
+      expect(prisma.mission.findUnique).toHaveBeenCalledWith({
+        where: { id: 'mission-1' },
+        include: detailInclude,
+      });
+      expect(result.owner.email).toBe('alice@example.com');
+      expect(result._count.submissions).toBe(5);
     });
 
-    expect(prisma.mission.findMany).toHaveBeenCalledWith({
-      where: { status: MissionStatus.OPEN },
-      orderBy: { createdAt: 'desc' },
-      take: undefined,
-    });
-  });
+    it('throws NotFoundException when mission does not exist', async () => {
+      prisma.mission.findUnique.mockResolvedValue(null);
 
-  it('uses default newest ordering when no query params are provided', async () => {
-    prisma.mission.findMany.mockResolvedValue([]);
-
-    await service.listPublicMissions({});
-
-    expect(prisma.mission.findMany).toHaveBeenCalledWith({
-      where: {},
-      orderBy: { createdAt: 'desc' },
-      take: undefined,
-    });
-  });
-
-  it('supports oldest sorting for public mission discovery', async () => {
-    prisma.mission.findMany.mockResolvedValue([]);
-
-    await service.listPublicMissions({
-      sort: MissionListSort.OLDEST,
-    });
-
-    expect(prisma.mission.findMany).toHaveBeenCalledWith({
-      where: {},
-      orderBy: { createdAt: 'asc' },
-      take: undefined,
+      await expect(service.getMission('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -1,10 +1,35 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { MissionStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   ListMissionsQueryDto,
   MissionListSort,
 } from './dto/list-missions-query.dto';
+
+const missionListInclude = {
+  owner: {
+    select: {
+      address: true,
+      displayName: true,
+    },
+  },
+  _count: {
+    select: { submissions: true },
+  },
+} as const;
+
+const missionDetailInclude = {
+  owner: {
+    select: {
+      address: true,
+      displayName: true,
+      email: true,
+    },
+  },
+  _count: {
+    select: { submissions: true },
+  },
+} as const;
 
 @Injectable()
 export class MissionsService {
@@ -23,8 +48,22 @@ export class MissionsService {
       where,
       orderBy,
       take: query.limit,
+      include: missionListInclude,
     });
 
     return missions as unknown;
+  }
+
+  async getMission(id: string): Promise<unknown> {
+    const mission = await this.prisma.mission.findUnique({
+      where: { id },
+      include: missionDetailInclude,
+    });
+
+    if (!mission) {
+      throw new NotFoundException(`Mission ${id} not found`);
+    }
+
+    return mission as unknown;
   }
 }


### PR DESCRIPTION
Added the Prisma include shape for mission list and detail queries to expose owner metadata and submission counts.

Closes #99 