### PR TITLE
feat(backend): add mission sort and limit handling

### DIFF
--- a/backend/src/missions/dto/list-missions-query.dto.ts
+++ b/backend/src/missions/dto/list-missions-query.dto.ts
@@ -4,6 +4,7 @@ import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 export enum MissionListSort {
   NEWEST = 'newest',
   OLDEST = 'oldest',
+  HIGHEST_REWARD = 'highest_reward',
 }
 
 export class ListMissionsQueryDto {

--- a/backend/src/missions/missions.service.spec.ts
+++ b/backend/src/missions/missions.service.spec.ts
@@ -43,7 +43,7 @@ describe('MissionsService', () => {
     expect(prisma.mission.findMany).toHaveBeenCalledWith({
       where: { status: MissionStatus.OPEN },
       orderBy: { createdAt: 'desc' },
-      take: undefined,
+      take: 20,
     });
   });
 
@@ -55,7 +55,7 @@ describe('MissionsService', () => {
     expect(prisma.mission.findMany).toHaveBeenCalledWith({
       where: {},
       orderBy: { createdAt: 'desc' },
-      take: undefined,
+      take: 20,
     });
   });
 
@@ -69,7 +69,36 @@ describe('MissionsService', () => {
     expect(prisma.mission.findMany).toHaveBeenCalledWith({
       where: {},
       orderBy: { createdAt: 'asc' },
-      take: undefined,
+      take: 20,
+    });
+  });
+
+  it('sorts by rewardAmount desc when sort is highest_reward', async () => {
+    prisma.mission.findMany.mockResolvedValue([]);
+
+    await service.listPublicMissions({
+      sort: MissionListSort.HIGHEST_REWARD,
+    });
+
+    expect(prisma.mission.findMany).toHaveBeenCalledWith({
+      where: {},
+      orderBy: { rewardAmount: 'desc' },
+      take: 20,
+    });
+  });
+
+  it('respects an explicit limit when provided', async () => {
+    prisma.mission.findMany.mockResolvedValue([]);
+
+    await service.listPublicMissions({
+      sort: MissionListSort.HIGHEST_REWARD,
+      limit: 10,
+    });
+
+    expect(prisma.mission.findMany).toHaveBeenCalledWith({
+      where: {},
+      orderBy: { rewardAmount: 'desc' },
+      take: 10,
     });
   });
 });

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -15,14 +15,15 @@ export class MissionsService {
       | MissionStatus
       | undefined;
     const where = normalizedStatus ? { status: normalizedStatus } : {};
-    const orderBy = {
-      createdAt: query.sort === MissionListSort.OLDEST ? 'asc' : 'desc',
-    } as const;
+    const orderBy =
+      query.sort === MissionListSort.HIGHEST_REWARD
+        ? { rewardAmount: 'desc' as const }
+        : { createdAt: query.sort === MissionListSort.OLDEST ? 'asc' : 'desc' as const };
 
     const missions = await this.prisma.mission.findMany({
       where,
       orderBy,
-      take: query.limit,
+      take: query.limit ?? 20,
     });
 
     return missions as unknown;


### PR DESCRIPTION
Added support the highest_reward sorting path, default recency sort, and default list limit.

Closes #98 