### PR TITLE
feat(backend): issue jwt after wallet verification

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { AuthService } from './auth.service';
+import { VerifySignatureDto } from './dto/verify-signature.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -8,5 +9,10 @@ export class AuthController {
   @Get('challenge')
   generateChallenge(@Query('address') address: string) {
     return this.authService.generateChallenge(address);
+  }
+
+  @Post('verify')
+  verify(@Body() dto: VerifySignatureDto) {
+    return this.authService.verifySignedPayload(dto.signedXdr);
   }
 }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,5 +1,6 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Keypair, WebAuth } from '@stellar/stellar-sdk';
 import { PrismaService } from '../prisma/prisma.service';
@@ -15,6 +16,25 @@ const mockConfig: Partial<Record<string, string>> = {
   STELLAR_NETWORK: 'Test SDF Network ; September 2015',
 };
 
+const mockConfigService = {
+  getOrThrow: (key: string) => {
+    if (mockConfig[key] === undefined) throw new Error(`Missing ${key}`);
+    return mockConfig[key];
+  },
+  get: (key: string, defaultValue?: string) => mockConfig[key] ?? defaultValue,
+};
+
+const mockPrismaService = {
+  user: {
+    upsert: jest.fn(),
+    findUnique: jest.fn(),
+  },
+};
+
+const mockJwtService = {
+  sign: jest.fn().mockReturnValue('mock.jwt.token'),
+};
+
 describe('AuthService - generateChallenge', () => {
   let service: AuthService;
 
@@ -22,22 +42,9 @@ describe('AuthService - generateChallenge', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
-        {
-          provide: PrismaService,
-          useValue: {},
-        },
-        {
-          provide: ConfigService,
-          useValue: {
-            getOrThrow: (key: string) => {
-              if (mockConfig[key] === undefined)
-                throw new Error(`Missing ${key}`);
-              return mockConfig[key];
-            },
-            get: (key: string, defaultValue?: string) =>
-              mockConfig[key] ?? defaultValue,
-          },
-        },
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: JwtService, useValue: mockJwtService },
       ],
     }).compile();
 
@@ -82,5 +89,76 @@ describe('AuthService - generateChallenge', () => {
 
   it('throws BadRequestException for an empty address', () => {
     expect(() => service.generateChallenge('')).toThrow(BadRequestException);
+  });
+});
+
+describe('AuthService - verifySignedPayload', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: JwtService, useValue: mockJwtService },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('upserts the user and returns { user, access_token } on first login', async () => {
+    const networkPassphrase = 'Test SDF Network ; September 2015';
+    const challenge = WebAuth.buildChallengeTx(
+      SERVER_KEYPAIR,
+      CLIENT_KEYPAIR.publicKey(),
+      'localhost',
+      300,
+      networkPassphrase,
+      'localhost',
+    );
+    const { tx } = WebAuth.readChallengeTx(
+      challenge,
+      SERVER_KEYPAIR.publicKey(),
+      networkPassphrase,
+      'localhost',
+      'localhost',
+    );
+    tx.sign(CLIENT_KEYPAIR);
+    const signedXdr = tx.toXDR();
+
+    const mockUser = {
+      id: 'uuid-123',
+      address: CLIENT_KEYPAIR.publicKey(),
+      email: null,
+      displayName: null,
+      bio: null,
+      role: 'EARNER',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    mockPrismaService.user.upsert.mockResolvedValue(mockUser);
+
+    const result = await service.verifySignedPayload(signedXdr);
+
+    expect(mockPrismaService.user.upsert).toHaveBeenCalledWith({
+      where: { address: CLIENT_KEYPAIR.publicKey() },
+      update: {},
+      create: { address: CLIENT_KEYPAIR.publicKey() },
+    });
+    expect(mockJwtService.sign).toHaveBeenCalledWith({
+      sub: 'uuid-123',
+      address: CLIENT_KEYPAIR.publicKey(),
+    });
+    expect(result).toEqual({ user: mockUser, access_token: 'mock.jwt.token' });
+  });
+
+  it('throws UnauthorizedException for an invalid signed XDR', async () => {
+    await expect(service.verifySignedPayload('invalid-xdr')).rejects.toThrow(
+      UnauthorizedException,
+    );
   });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { User } from '@prisma/client';
 import {
   Keypair,
   Networks,
@@ -33,31 +34,25 @@ export class AuthService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly config: ConfigService,
-    private readonly serverAccountId: string,
-    private readonly networkPassphrase: string,
-    private readonly horizonUrl: string,
     private readonly jwtService: JwtService,
   ) {}
 
   private getSep10Config() {
-    const homeDomain = this.config.get<string>('STELLAR_HOME_DOMAIN') || '';
-    const webAuthDomain =
-      this.config.get<string>('STELLAR_WEB_AUTH_DOMAIN') || '';
-
-    if (!homeDomain) {
-      throw new Error('STELLAR_HOME_DOMAIN environment variable is required');
-    }
-
-    if (!webAuthDomain) {
-      throw new Error(
-        'STELLAR_WEB_AUTH_DOMAIN environment variable is required',
-      );
-    }
+    const serverSecret = this.config.getOrThrow<string>(
+      'STELLAR_SERVER_SECRET',
+    );
+    const serverAccountId = Keypair.fromSecret(serverSecret).publicKey();
+    const networkPassphrase = this.config.get<string>(
+      'STELLAR_NETWORK',
+      Networks.TESTNET,
+    );
+    const homeDomain = this.config.getOrThrow<string>('HOME_DOMAIN');
+    const webAuthDomain = this.config.getOrThrow<string>('WEB_AUTH_DOMAIN');
 
     return {
-      serverAccountId: this.serverAccountId,
+      serverAccountId,
       homeDomain,
-      networkPassphrase: this.networkPassphrase,
+      networkPassphrase,
       webAuthDomain,
     };
   }
@@ -106,7 +101,9 @@ export class AuthService {
     };
   }
 
-  verifySignedPayload(_signedXdr: string): string {
+  async verifySignedPayload(
+    _signedXdr: string,
+  ): Promise<{ user: User; access_token: string }> {
     const { serverAccountId, homeDomain, networkPassphrase, webAuthDomain } =
       this.getSep10Config();
 
@@ -134,9 +131,16 @@ export class AuthService {
     }
   }
 
-  private issueTokenForAddress(address: string): string {
-    const payload = { sub: address };
-    return this.jwtService.sign(payload);
+  private async issueTokenForAddress(
+    address: string,
+  ): Promise<{ user: User; access_token: string }> {
+    const user = await this.prisma.user.upsert({
+      where: { address },
+      update: {},
+      create: { address },
+    });
+    const access_token = this.jwtService.sign({ sub: user.id, address });
+    return { user, access_token };
   }
 
   private getSep10ErrorMessage(error: unknown): string {
@@ -151,7 +155,7 @@ export class AuthService {
     return 'Invalid SEP-10 challenge response';
   }
 
-  validateUser(publicKey: string) {
-    return this.prisma.user.findUnique({ where: { email: publicKey } });
+  validateUser(address: string) {
+    return this.prisma.user.findUnique({ where: { address } });
   }
 }

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -4,7 +4,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
 interface JwtPayload {
-  userId: string;
+  sub: string;
   address: string;
   iat: number;
   exp: number;
@@ -23,6 +23,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   validate(payload: JwtPayload) {
-    return { userId: payload.userId, address: payload.address };
+    return { userId: payload.sub, address: payload.address };
   }
 }


### PR DESCRIPTION
- Upsert user row on first SEP-10 verification via prisma.user.upsert
- Sign JWT with payload { sub: user.id, address } on successful auth
- Return { user, access_token } from verifySignedPayload
- Add POST /auth/verify endpoint to AuthController
- Fix JwtStrategy payload shape to use sub instead of userId
- Fix constructor to derive serverAccountId/networkPassphrase from ConfigService
- Fix validateUser to look up by address instead of email
- Add verifySignedPayload unit tests covering upsert and invalid XDR

Closes #93 