### PR TITLE
Expose the GET /missions/:id route and return one mission with its included data.

### DIFF
--- a/backend/src/missions/dto/list-missions-query.dto.ts
+++ b/backend/src/missions/dto/list-missions-query.dto.ts
@@ -6,6 +6,14 @@ export enum MissionListSort {
   OLDEST = 'oldest',
 }
 
+export enum MissionQueryStatus {
+  OPEN = 'OPEN',
+  STARTED = 'STARTED',
+  PAUSED = 'PAUSED',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+}
+
 export class ListMissionsQueryDto {
   @IsOptional()
   @IsString()

--- a/backend/src/missions/missions.controller.spec.ts
+++ b/backend/src/missions/missions.controller.spec.ts
@@ -8,11 +8,12 @@ import {
 
 describe('MissionsController', () => {
   let controller: MissionsController;
-  let missionsService: { listPublicMissions: jest.Mock };
+  let missionsService: { listPublicMissions: jest.Mock; getMission: jest.Mock };
 
   beforeEach(() => {
     missionsService = {
       listPublicMissions: jest.fn(),
+      getMission: jest.fn(),
     };
 
     controller = new MissionsController(
@@ -31,5 +32,13 @@ describe('MissionsController', () => {
 
     await expect(controller.list(query)).resolves.toEqual(['mission']);
     expect(missionsService.listPublicMissions).toHaveBeenCalledWith(query);
+  });
+
+  it('forwards the mission id to the service and returns the result', async () => {
+    const mockMission = { id: 'mission-1', title: 'Test' };
+    missionsService.getMission.mockResolvedValue(mockMission);
+
+    await expect(controller.detail('mission-1')).resolves.toEqual(mockMission);
+    expect(missionsService.getMission).toHaveBeenCalledWith('mission-1');
   });
 });

--- a/backend/src/missions/missions.service.spec.ts
+++ b/backend/src/missions/missions.service.spec.ts
@@ -94,7 +94,9 @@ describe('MissionsService', () => {
       };
       prisma.mission.findMany.mockResolvedValue([mockMission]);
 
-      const result = await service.listPublicMissions({}) as typeof mockMission[];
+      const result = (await service.listPublicMissions(
+        {},
+      )) as (typeof mockMission)[];
 
       expect(result[0].owner.address).toBe('0xabc');
       expect(result[0].owner.displayName).toBe('Alice');
@@ -106,12 +108,18 @@ describe('MissionsService', () => {
     it('returns a mission with owner address, displayName, email, and submission count', async () => {
       const mockMission = {
         id: 'mission-1',
-        owner: { address: '0xabc', displayName: 'Alice', email: 'alice@example.com' },
+        owner: {
+          address: '0xabc',
+          displayName: 'Alice',
+          email: 'alice@example.com',
+        },
         _count: { submissions: 5 },
       };
       prisma.mission.findUnique.mockResolvedValue(mockMission);
 
-      const result = await service.getMission('mission-1') as typeof mockMission;
+      const result = (await service.getMission(
+        'mission-1',
+      )) as typeof mockMission;
 
       expect(prisma.mission.findUnique).toHaveBeenCalledWith({
         where: { id: 'mission-1' },

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -51,7 +51,7 @@ export class MissionsService {
       include: missionListInclude,
     });
 
-    return missions as unknown;
+    return missions;
   }
 
   async getMission(id: string): Promise<unknown> {
@@ -64,6 +64,6 @@ export class MissionsService {
       throw new NotFoundException(`Mission ${id} not found`);
     }
 
-    return mission as unknown;
+    return mission;
   }
 }


### PR DESCRIPTION
closes #100 