### PR TITLE
feat(missions): add GET /missions/me endpoint

### DIFF
--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -1,5 +1,0 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
-
-describe('AppController', () => {});

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -1,0 +1,5 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+describe('AppController', () => {});

--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
 import { MissionsService } from './missions.service';
 import { ListMissionsQueryDto } from './dto/list-missions-query.dto';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 
 @Controller('missions')
 export class MissionsController {
@@ -9,6 +10,12 @@ export class MissionsController {
   @Get()
   list(@Query() query: ListMissionsQueryDto): Promise<unknown> {
     return this.missionsService.listPublicMissions(query);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('me')
+  me(@Req() req: Request & { user: { address: string } }): Promise<unknown> {
+    return this.missionsService.getMyMissions(req.user.address);
   }
 
   @Get(':id')

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -66,4 +66,12 @@ export class MissionsService {
 
     return mission;
   }
+
+  async getMyMissions(ownerAddress: string): Promise<unknown> {
+    return this.prisma.mission.findMany({
+      where: { ownerAddress },
+      orderBy: { createdAt: 'desc' },
+      include: missionListInclude,
+    });
+  }
 }


### PR DESCRIPTION
feat(backend): add my missions endpoint

closes #101 

Exposes a protected GET /missions/me route that returns the authenticated user's missions ordered by createdAt desc. Route is guarded with JwtAuthGuard and reads the wallet address from request.user.address.