### PR TITLE
feat(backend): add save draft route, and protect private mission routes

### DIFF
--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { MissionsService } from './missions.service';
 import { ListMissionsQueryDto } from './dto/list-missions-query.dto';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+
+type AuthRequest = Request & { user: { address: string } };
 
 @Controller('missions')
 export class MissionsController {
@@ -9,6 +12,24 @@ export class MissionsController {
   @Get()
   list(@Query() query: ListMissionsQueryDto): Promise<unknown> {
     return this.missionsService.listPublicMissions(query);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('me')
+  me(@Req() req: AuthRequest): Promise<unknown> {
+    return this.missionsService.getMyMissions(req.user.address);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('draft')
+  saveDraft(@Req() req: AuthRequest, @Body() body: unknown): Promise<unknown> {
+    return this.missionsService.saveDraft(req.user.address, body);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get(':id/submissions')
+  submissions(@Param('id') id: string, @Req() req: AuthRequest): Promise<unknown> {
+    return this.missionsService.getMissionSubmissions(id, req.user.address);
   }
 
   @Get(':id')

--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -32,7 +32,10 @@ export class MissionsController {
 
   @UseGuards(JwtAuthGuard)
   @Post('draft')
-  saveDraft(@Req() req: AuthRequest, @Body() body: string): Promise<unknown> {
+  saveDraft(
+    @Req() req: AuthRequest,
+    @Body() body: string,
+  ): { id: string; body: string } {
     return this.missionsService.saveDraft(req.user.address, body);
   }
 

--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -1,15 +1,15 @@
-import {
-  Controller,
-  Get,
-  Param,
-  Query,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
 import { Request } from 'express';
 import { MissionsService } from './missions.service';
 import { ListMissionsQueryDto } from './dto/list-missions-query.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+interface AuthenticatedRequest extends Request {
+  user: {
+    userId: string;
+    address: string;
+  };
+}
 
 @Controller('missions')
 export class MissionsController {
@@ -29,5 +29,14 @@ export class MissionsController {
   @Get(':id')
   detail(@Param('id') id: string): Promise<unknown> {
     return this.missionsService.getMission(id);
+  }
+
+  @Get(':id/submissions')
+  @UseGuards(JwtAuthGuard)
+  submissions(
+    @Param('id') id: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<unknown> {
+    return this.missionsService.getMissionSubmissions(id, req.user.address);
   }
 }

--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -32,7 +32,7 @@ export class MissionsController {
 
   @UseGuards(JwtAuthGuard)
   @Post('draft')
-  saveDraft(@Req() req: AuthRequest, @Body() body: string): Promise<{}> {
+  saveDraft(@Req() req: AuthRequest, @Body() body: string): Promise<unknown> {
     return this.missionsService.saveDraft(req.user.address, body);
   }
 

--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -15,13 +15,6 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 type AuthRequest = Request & { user: { address: string } };
 
-interface AuthenticatedRequest extends Request {
-  user: {
-    userId: string;
-    address: string;
-  };
-}
-
 @Controller('missions')
 export class MissionsController {
   constructor(private readonly missionsService: MissionsService) {}

--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -1,9 +1,7 @@
 import {
-  Body,
   Controller,
   Get,
   Param,
-  Post,
   Query,
   Req,
   UseGuards,
@@ -12,8 +10,6 @@ import { Request } from 'express';
 import { MissionsService } from './missions.service';
 import { ListMissionsQueryDto } from './dto/list-missions-query.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-
-type AuthRequest = Request & { user: { address: string } };
 
 @Controller('missions')
 export class MissionsController {

--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -22,7 +22,7 @@ export class MissionsController {
 
   @UseGuards(JwtAuthGuard)
   @Post('draft')
-  saveDraft(@Req() req: AuthRequest, @Body() body: unknown): Promise<unknown> {
+  saveDraft(@Req() req: AuthRequest, @Body() body: string): Promise<{}> {
     return this.missionsService.saveDraft(req.user.address, body);
   }
 

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -79,11 +79,8 @@ export class MissionsService {
     });
   }
 
-  async saveDraft(id: string, body: string): Promise<unknown> {
-    return await this.prisma.mission.update({
-      where: { id },
-      data: { body, status: 'DRAFT' },
-    });
+  saveDraft(id: string, body: string): { id: string; body: string } {
+    return { id, body };
   }
 
   async getMissionSubmissions(

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -79,14 +79,6 @@ export class MissionsService {
     return mission;
   }
 
-  async getMyMissions(id: string): Promise<unknown> {
-    return await this.prisma.mission.findMany({
-      where: { id },
-      orderBy: { createdAt: 'desc' },
-      include: missionListInclude,
-    });
-  }
-
   saveDraft(id: string, body: string): { id: string; body: string } {
     return { id, body };
   }

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -66,4 +66,16 @@ export class MissionsService {
 
     return mission;
   }
+
+  async getMyMissions(id: string): Promise<unknown> {
+    return
+  }
+
+  async saveDraft(id: string, body: string): Promise<{}> {
+   return {id, body}
+  }
+
+  async getMissionSubmissions(id: string, req: {}): Promise<unknown> {
+   return
+  }
 }

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -72,11 +72,18 @@ export class MissionsService {
   }
 
   async getMyMissions(id: string): Promise<unknown> {
-    return;
+    return await this.prisma.mission.findMany({
+      where: { id },
+      orderBy: { createdAt: 'desc' },
+      include: missionListInclude,
+    });
   }
 
-  async saveDraft(id: string, body: string): Promise<{}> {
-    return { id, body };
+  async saveDraft(id: string, body: string): Promise<unknown> {
+    return await this.prisma.mission.update({
+      where: { id },
+      data: { body, status: 'DRAFT' },
+    });
   }
 
   async getMissionSubmissions(


### PR DESCRIPTION
Exposes a protected POST /missions/draft route that reads the wallet
address from request.user.address and delegates the raw payload to the service.

closes #104 

Guards GET /missions/me, GET /missions/:id/submissions, and POST /missions/draft
with JwtAuthGuard. Public routes GET /missions and GET /missions/:id remain unguarded.

closes #109 