### PR TITLE
feat:BE-049 Indexer state upsert

### DIFF
--- a/backend/src/indexer/indexer.service.ts
+++ b/backend/src/indexer/indexer.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class IndexerService {
+  private readonly logger = new Logger(IndexerService.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  // BE-047: 10-second cron scaffold
+  @Cron(CronExpression.EVERY_10_SECONDS)
+  async pollEvents(): Promise<void> {
+    // BE-048: config gating — skip gracefully when chain config is absent
+    const rpcUrl = this.config.get<string>('RPC_URL');
+    const contractId = this.config.get<string>('CONTRACT_ID');
+
+    if (!rpcUrl || !contractId) {
+      this.logger.debug(
+        'Skipping indexer tick: RPC_URL or CONTRACT_ID is not configured.',
+      );
+      return;
+    }
+
+    // BE-049: upsert singleton IndexerState checkpoint row
+    await this.prisma.indexerState.upsert({
+      where: { id: 1 },
+      create: { id: 1, lastLedger: BigInt(0) },
+      update: {},
+    });
+
+    this.logger.debug('Indexer tick complete — IndexerState checkpoint upserted.');
+  }
+}

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -22,6 +22,7 @@ export class PrismaService
   async onModuleInit() {
     await this.$connect();
   }
+
   async onModuleDestroy() {
     await this.$disconnect();
   }


### PR DESCRIPTION
<html><head></head><body><h1>feat(backend): add indexer cron task, config gating &amp; state upsert</h1>
<h2>Tickets</h2>
<p>Closes BE-047 · BE-048 · BE-049
Depends on BE-002 · BE-010 · BE-046</p>
<hr>
<h2>What changed</h2>
<p><code>backend/src/indexer/indexer.service.ts</code> — new file.</p>

Ticket | Change
-- | --
BE-047 | IndexerService created with ConfigService + PrismaService injected. pollEvents() decorated with @Cron(CronExpression.EVERY_10_SECONDS).
BE-048 | At the start of every tick, RPC_URL and CONTRACT_ID are read from ConfigService. If either is absent a DEBUG message is logged and the method returns early — no throw, no crash.
BE-049 | When config is present, prisma.indexerState.upsert ensures the singleton row (id = 1, lastLedger = 0n) exists. The update payload is intentionally empty so future ledger writes own that field.


<hr>
<h2>CI checklist</h2>
<ul>
<li>[x] No new <code>any</code> / unsafe casts</li>
<li>[x] All injected dependencies are typed with concrete classes (no implicit <code>any</code>)</li>
<li>[x] <code>BigInt(0)</code> / <code>0n</code> used correctly for Prisma <code>BigInt</code> field</li>
<li>[x] Early return path is silent (debug-level only) — won't spam logs in staging</li>
<li>[x] No circular imports — <code>PrismaService</code> and <code>ConfigService</code> are both root-level providers</li>
<li>[x] <code>@nestjs/schedule</code> must be listed in <code>package.json</code> and <code>ScheduleModule.forRoot()</code> registered in the app module (pre-existing dependency from BE-046)</li>
</ul>
<hr>
<h2>Testing notes</h2>
<ul>
<li>Unit test: mock <code>ConfigService.get</code> to return <code>undefined</code> → assert <code>prisma.indexerState.upsert</code> is <strong>not</strong> called.</li>
<li>Unit test: mock both config values → assert upsert is called with <code>{ where: { id: 1 }, create: { id: 1, lastLedger: 0n }, update: {} }</code>.</li>
<li>Integration: boot the app without <code>RPC_URL</code> in <code>.env</code> and confirm no crash + debug log appears every 10 s.</li>
</ul></body></html>


Closes #116
Closes #117
Closes #118

