### PR TITLE
feat(backend): protect upload routes

### DIFF
--- a/backend/src/upload/upload.controller.ts
+++ b/backend/src/upload/upload.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Post, UseInterceptors, UploadedFile, Body } from '@nestjs/common';
+import { Controller, Post, UseGuards, UseInterceptors, UploadedFile, Body } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { UploadService } from './upload.service';
 import { UploadedFilePayload } from './upload.types';
 
@@ -8,12 +9,14 @@ export class UploadController {
   constructor(private readonly uploadService: UploadService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('file'))
   uploadFile(@UploadedFile() file: UploadedFilePayload) {
     return this.uploadService.uploadFile(file);
   }
 
   @Post('json')
+  @UseGuards(JwtAuthGuard)
   uploadJson(@Body() payload: any) {
     return this.uploadService.uploadJson(payload);
   }


### PR DESCRIPTION
## Summary

- Applied `JwtAuthGuard` to `POST /upload` and `POST /upload/json`
- Anonymous requests to both endpoints now receive `401 Unauthorized`
- Authenticated requests are unaffected — controller behavior unchanged

## Changes

- `backend/src/upload/upload.controller.ts` — added `@UseGuards(JwtAuthGuard)` to both upload routes

## Dependencies

- Depends on #BE-020
- Depends on #BE-042

Closes #114
