### PR TITLE
feat(contracts): scaffold milestone escrow crate and add status enums

### DIFF
--- a/quid-contract/Cargo.lock
+++ b/quid-contract/Cargo.lock
@@ -983,6 +983,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "quid-milestone-escrow"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "quid-store"
 version = "0.0.0"
 dependencies = [

--- a/quid-contract/contracts/quid-milestone-escrow/Cargo.toml
+++ b/quid-contract/contracts/quid-milestone-escrow/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "quid-milestone-escrow"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/quid-contract/contracts/quid-milestone-escrow/src/error.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/error.rs
@@ -1,0 +1,7 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MilestoneEscrowError {
+    InvalidState = 1,
+}

--- a/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
@@ -1,0 +1,42 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Env};
+
+mod error;
+mod types;
+
+use types::{DataKey, MilestoneStatus, ProgramStatus};
+
+#[contract]
+pub struct QuidMilestoneEscrowContract;
+
+#[contractimpl]
+impl QuidMilestoneEscrowContract {
+    pub fn get_program_status(env: Env) -> ProgramStatus {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ProgramStatus)
+            .unwrap_or_default()
+    }
+
+    pub fn set_program_status(env: Env, status: ProgramStatus) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProgramStatus, &status);
+    }
+
+    pub fn get_milestone_status(env: Env) -> MilestoneStatus {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MilestoneStatus)
+            .unwrap_or_default()
+    }
+
+    pub fn set_milestone_status(env: Env, status: MilestoneStatus) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::MilestoneStatus, &status);
+    }
+}
+
+mod test;

--- a/quid-contract/contracts/quid-milestone-escrow/src/test.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/test.rs
@@ -1,0 +1,28 @@
+#![cfg(test)]
+
+use super::*;
+use crate::types::{MilestoneStatus, ProgramStatus};
+use soroban_sdk::Env;
+
+#[test]
+fn test_default_statuses() {
+    let env = Env::default();
+    let contract_id = env.register(QuidMilestoneEscrowContract, ());
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_program_status(), ProgramStatus::Active);
+    assert_eq!(client.get_milestone_status(), MilestoneStatus::Pending);
+}
+
+#[test]
+fn test_status_storage_roundtrip() {
+    let env = Env::default();
+    let contract_id = env.register(QuidMilestoneEscrowContract, ());
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+
+    client.set_program_status(&ProgramStatus::Completed);
+    client.set_milestone_status(&MilestoneStatus::Paid);
+
+    assert_eq!(client.get_program_status(), ProgramStatus::Completed);
+    assert_eq!(client.get_milestone_status(), MilestoneStatus::Paid);
+}

--- a/quid-contract/contracts/quid-milestone-escrow/src/types.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/types.rs
@@ -1,0 +1,25 @@
+use soroban_sdk::contracttype;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Copy)]
+#[contracttype]
+pub enum ProgramStatus {
+    #[default]
+    Active,
+    Completed,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Copy)]
+#[contracttype]
+pub enum MilestoneStatus {
+    #[default]
+    Pending,
+    Paid,
+    Cancelled,
+}
+
+#[contracttype]
+pub enum DataKey {
+    ProgramStatus,
+    MilestoneStatus,
+}


### PR DESCRIPTION
PR description:
- Combines #171 and #172.
- Adds quid-milestone-escrow Soroban contract crate scaffold ( Cargo.toml , lib.rs , types.rs , error.rs , test.rs ) using soroban-sdk = { workspace = true } and testutils for dev-deps.
- Introduces ProgramStatus (Active default, Completed, Cancelled) and MilestoneStatus (Pending default, Paid, Cancelled) as #[contracttype] enums suitable for storage and equality checks.
- Validated with cargo test -p quid-milestone-escrow .

closes #171 
closes #172 
