### PR TITLE
Contracts: implement create program and add program read helpers

### DIFF
--- a/quid-contract/contracts/quid-milestone-escrow/src/error.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/error.rs
@@ -4,4 +4,6 @@ use soroban_sdk::contracterror;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum MilestoneEscrowError {
     InvalidState = 1,
+    InvalidAmount = 2,
+    ProgramNotFound = 3,
 }

--- a/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
@@ -1,17 +1,91 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Env};
+use soroban_sdk::{contract, contractevent, contractimpl, token, Address, Env, String};
 
 mod error;
 pub mod types;
 
-use types::{DataKey, MilestoneStatus, ProgramStatus};
+use error::MilestoneEscrowError;
+use types::{DataKey, MilestoneStatus, Program, ProgramStatus};
+
+#[contractevent(topics = ["program", "created"])]
+pub struct ProgramCreatedEvent {
+    pub program_id: u64,
+    pub sponsor: Address,
+    pub recipient: Address,
+}
+
+#[contractevent(topics = ["program", "status_changed"])]
+pub struct ProgramStatusChangedEvent {
+    pub program_id: u64,
+    pub status: ProgramStatus,
+}
 
 #[contract]
 pub struct QuidMilestoneEscrowContract;
 
 #[contractimpl]
 impl QuidMilestoneEscrowContract {
+    pub fn create_program(
+        env: Env,
+        sponsor: Address,
+        recipient: Address,
+        token: Address,
+        total_amount: i128,
+        reviewer: Option<Address>,
+        metadata_cid: Option<String>,
+    ) -> Result<u64, MilestoneEscrowError> {
+        sponsor.require_auth();
+
+        if total_amount <= 0 {
+            return Err(MilestoneEscrowError::InvalidAmount);
+        }
+
+        token::Client::new(&env, &token).transfer(
+            &sponsor,
+            &env.current_contract_address(),
+            &total_amount,
+        );
+
+        let program_id = Self::get_next_program_id(&env);
+        let status = ProgramStatus::Active;
+        let program = Program {
+            id: program_id,
+            sponsor: sponsor.clone(),
+            recipient: recipient.clone(),
+            reviewer,
+            token,
+            total_amount,
+            allocated_amount: 0,
+            released_amount: 0,
+            milestone_count: 0,
+            metadata_cid,
+            created_at: env.ledger().timestamp(),
+            status,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Program(program_id), &program);
+
+        ProgramCreatedEvent {
+            program_id,
+            sponsor,
+            recipient,
+        }
+        .publish(&env);
+        ProgramStatusChangedEvent { program_id, status }.publish(&env);
+
+        Ok(program_id)
+    }
+
+    pub fn get_program(env: Env, program_id: u64) -> Result<Program, MilestoneEscrowError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Program(program_id))
+            .ok_or(MilestoneEscrowError::ProgramNotFound)
+    }
+
     pub fn get_program_status(env: Env) -> ProgramStatus {
         env.storage()
             .persistent()
@@ -36,6 +110,24 @@ impl QuidMilestoneEscrowContract {
         env.storage()
             .persistent()
             .set(&DataKey::MilestoneStatus, &status);
+    }
+
+    pub fn get_program_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ProgramCount)
+            .unwrap_or(0)
+    }
+
+    fn get_next_program_id(env: &Env) -> u64 {
+        let mut count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProgramCount)
+            .unwrap_or(0);
+        count += 1;
+        env.storage().instance().set(&DataKey::ProgramCount, &count);
+        count
     }
 }
 

--- a/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
@@ -43,7 +43,7 @@ impl QuidMilestoneEscrowContract {
 
         token::Client::new(&env, &token).transfer(
             &sponsor,
-            &env.current_contract_address(),
+            env.current_contract_address(),
             &total_amount,
         );
 

--- a/quid-contract/contracts/quid-milestone-escrow/src/test.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/test.rs
@@ -2,7 +2,23 @@
 
 use super::*;
 use crate::types::{MilestoneStatus, ProgramStatus};
-use soroban_sdk::Env;
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env, String};
+
+fn setup_test_env() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuidMilestoneEscrowContract, ());
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+    let sponsor = Address::generate(&env);
+    let token_admin_client = StellarAssetClient::new(&env, &token_address);
+    token_admin_client.mint(&sponsor, &1_000_000);
+
+    (env, contract_id, sponsor, token_address)
+}
 
 #[test]
 fn test_default_statuses() {
@@ -25,4 +41,56 @@ fn test_status_storage_roundtrip() {
 
     assert_eq!(client.get_program_status(), ProgramStatus::Completed);
     assert_eq!(client.get_milestone_status(), MilestoneStatus::Paid);
+}
+
+#[test]
+fn test_create_program_funds_and_stores_active_program() {
+    let (env, contract_id, sponsor, token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token_address);
+    let recipient = Address::generate(&env);
+    let reviewer = Address::generate(&env);
+    let total_amount = 500;
+
+    let program_id = client.create_program(
+        &sponsor,
+        &recipient,
+        &token_address,
+        &total_amount,
+        &Some(reviewer.clone()),
+        &Some(String::from_str(&env, "QmProgram")),
+    );
+    let contract_event_count = env
+        .events()
+        .all()
+        .iter()
+        .filter(|(id, _, _)| id == &contract_id)
+        .count();
+
+    assert_eq!(program_id, 1);
+    assert_eq!(contract_event_count, 2);
+    assert_eq!(token_client.balance(&contract_id), total_amount);
+    assert_eq!(client.get_program_count(), 1);
+
+    let program = client.get_program(&program_id);
+    assert_eq!(program.id, program_id);
+    assert_eq!(program.sponsor, sponsor);
+    assert_eq!(program.recipient, recipient);
+    assert_eq!(program.reviewer, Some(reviewer));
+    assert_eq!(program.token, token_address);
+    assert_eq!(program.total_amount, total_amount);
+    assert_eq!(program.allocated_amount, 0);
+    assert_eq!(program.released_amount, 0);
+    assert_eq!(program.milestone_count, 0);
+    assert_eq!(program.status, ProgramStatus::Active);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_create_program_rejects_zero_amount() {
+    let (env, contract_id, sponsor, token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+
+    let _ = client.create_program(&sponsor, &recipient, &token_address, &0, &None, &None);
 }

--- a/quid-contract/contracts/quid-milestone-escrow/src/test.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/test.rs
@@ -94,3 +94,12 @@ fn test_create_program_rejects_zero_amount() {
 
     let _ = client.create_program(&sponsor, &recipient, &token_address, &0, &None, &None);
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_get_program_not_found() {
+    let (env, contract_id, _sponsor, _token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+
+    let _ = client.get_program(&999);
+}


### PR DESCRIPTION
## Summary

Implements the milestone escrow program creation and read paths.

## Changes

- Added `create_program` entrypoint for funded program creation.
- Requires sponsor authorization before escrow funding.
- Validates `total_amount > 0`.
- Transfers funds from sponsor to the escrow contract.
- Stores new programs in `Active` status with:
  - `allocated_amount = 0`
  - `released_amount = 0`
  - `milestone_count = 0`
- Publishes `ProgramCreatedEvent`.
- Publishes `ProgramStatusChangedEvent`.
- Added `get_program` read method.
- Added `get_program_count` helper.
- Added internal `get_next_program_id` counter helper.
- Added `ProgramNotFound` and `InvalidAmount` errors.
- Added tests for funded creation, stored state, event publishing, invalid amount rejection, program count, and missing program lookup.

## Testing

```bash
cargo fmt -p quid-milestone-escrow
cargo test -p quid-milestone-escrow
```

Result: all 5 tests pass.

## Issues

Closes #177
Closes #178 