### PR TITLE
feat(contracts): implement issue attestation

### DIFF
--- a/quid-contract/Cargo.lock
+++ b/quid-contract/Cargo.lock
@@ -991,9 +991,7 @@ dependencies = [
 
 [[package]]
 name = "quid-reputation"
-
 version = "0.1.0"
-
 dependencies = [
  "soroban-sdk",
 ]

--- a/quid-contract/Cargo.lock
+++ b/quid-contract/Cargo.lock
@@ -990,6 +990,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "quid-reputation"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "quid-store"
 version = "0.0.0"
 dependencies = [

--- a/quid-contract/contracts/quid-reputation/Cargo.toml
+++ b/quid-contract/contracts/quid-reputation/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "quid-reputation"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/quid-contract/contracts/quid-reputation/README.md
+++ b/quid-contract/contracts/quid-reputation/README.md
@@ -1,0 +1,140 @@
+# Quid Reputation Contract
+
+The Quid Reputation contract implements an on-chain attestation system for tracking contributor activity and reputation.
+
+## Features
+
+- **Issue Attestations**: Create portable attestations for contributor activity with metadata and optional expiry
+- **Revoke Attestations**: Issuers can revoke attestations they've issued
+- **Admin Management**: Bootstrap and manage contract admin
+- **Event Logging**: Publish events when attestations are issued or revoked
+
+## API
+
+### `bootstrap_admin(env, admin) -> Result<(), QuidError>`
+
+Initialize the contract admin. Can only be called once.
+
+**Parameters:**
+
+- `env`: Soroban environment
+- `admin`: Address of the admin
+
+**Returns:**
+
+- `Ok(())` on success
+- `Err(QuidError::NotAuthorized)` if admin is already set
+
+---
+
+### `get_admin(env) -> Result<Address, QuidError>`
+
+Get the current contract admin.
+
+**Parameters:**
+
+- `env`: Soroban environment
+
+**Returns:**
+
+- `Ok(Address)` - The admin address
+- `Err(QuidError::AdminNotSet)` if no admin is set
+
+---
+
+### `issue_attestation(env, issuer, subject, kind, label, metadata_cid, expires_at) -> Result<u64, QuidError>`
+
+Issue an attestation for a subject.
+
+**Parameters:**
+
+- `env`: Soroban environment
+- `issuer`: Address of the issuer (must authorize the transaction)
+- `subject`: Address of the attestation subject
+- `kind`: String describing the attestation type (e.g., "contributor", "expert")
+- `label`: String label for the attestation (must not be empty)
+- `metadata_cid`: Optional IPFS CID for additional metadata
+- `expires_at`: Optional timestamp when the attestation expires
+
+**Returns:**
+
+- `Ok(u64)` - The attestation ID
+- `Err(QuidError::NotAuthorized)` if issuer doesn't authorize
+- `Err(QuidError::InvalidLabel)` if label is empty
+- `Err(QuidError::InvalidExpiryTime)` if expiry is in the past
+
+**Events:**
+
+- Publishes `AttestationIssuedEvent` with attestation_id, issuer, and subject
+
+---
+
+### `get_attestation(env, attestation_id) -> Result<Attestation, QuidError>`
+
+Retrieve an attestation by ID.
+
+**Parameters:**
+
+- `env`: Soroban environment
+- `attestation_id`: The attestation ID
+
+**Returns:**
+
+- `Ok(Attestation)` - The attestation record
+- `Err(QuidError::AttestationNotFound)` if attestation doesn't exist
+
+---
+
+### `revoke_attestation(env, attestation_id) -> Result<(), QuidError>`
+
+Revoke an attestation (issuer only).
+
+**Parameters:**
+
+- `env`: Soroban environment
+- `attestation_id`: The attestation ID to revoke
+
+**Returns:**
+
+- `Ok(())` on success
+- `Err(QuidError::NotAuthorized)` if not the issuer
+- `Err(QuidError::AttestationNotFound)` if attestation doesn't exist
+- `Err(QuidError::AlreadyRevoked)` if already revoked
+
+**Events:**
+
+- Publishes `AttestationRevokedEvent` with attestation_id
+
+## Data Structures
+
+### Attestation
+
+```rust
+pub struct Attestation {
+    pub id: u64,
+    pub issuer: Address,
+    pub subject: Address,
+    pub kind: String,
+    pub label: String,
+    pub metadata_cid: Option<String>,
+    pub issued_at: u64,
+    pub expires_at: Option<u64>,
+    pub revoked: bool,
+}
+```
+
+## Testing
+
+Run tests with:
+
+```bash
+cargo test
+```
+
+## Build
+
+Build the contract with:
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```

--- a/quid-contract/contracts/quid-reputation/src/error.rs
+++ b/quid-contract/contracts/quid-reputation/src/error.rs
@@ -10,5 +10,4 @@ pub enum QuidError {
     AlreadyRevoked = 4,
     AdminNotSet = 5,
     InvalidLabel = 6,
-
 }

--- a/quid-contract/contracts/quid-reputation/src/error.rs
+++ b/quid-contract/contracts/quid-reputation/src/error.rs
@@ -1,0 +1,12 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum QuidError {
+    NotAuthorized = 1,
+    AttestationNotFound = 2,
+    InvalidExpiryTime = 3,
+    AlreadyRevoked = 4,
+    AdminNotSet = 5,
+    InvalidLabel = 6,
+}

--- a/quid-contract/contracts/quid-reputation/src/lib.rs
+++ b/quid-contract/contracts/quid-reputation/src/lib.rs
@@ -27,17 +27,11 @@ impl QuidReputationContract {
     /// Bootstrap admin for the contract
     pub fn bootstrap_admin(env: Env, admin: Address) -> Result<(), QuidError> {
         // Only allow setting admin if not already set
-        if env
-            .storage()
-            .persistent()
-            .has(&DataKey::Admin)
-        {
+        if env.storage().persistent().has(&DataKey::Admin) {
             return Err(QuidError::NotAuthorized);
         }
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Admin, &admin);
 
         env.storage()
             .persistent()
@@ -102,9 +96,11 @@ impl QuidReputationContract {
             .persistent()
             .set(&DataKey::Attestation(attestation_id), &attestation);
 
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Attestation(attestation_id), 5184000, 5184000);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Attestation(attestation_id),
+            5184000,
+            5184000,
+        );
 
         // Publish AttestationIssuedEvent
         AttestationIssuedEvent {
@@ -145,9 +141,11 @@ impl QuidReputationContract {
             .persistent()
             .set(&DataKey::Attestation(attestation_id), &attestation);
 
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Attestation(attestation_id), 5184000, 5184000);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Attestation(attestation_id),
+            5184000,
+            5184000,
+        );
 
         // Publish AttestationRevokedEvent
         AttestationRevokedEvent { attestation_id }.publish(&env);

--- a/quid-contract/contracts/quid-reputation/src/lib.rs
+++ b/quid-contract/contracts/quid-reputation/src/lib.rs
@@ -1,0 +1,178 @@
+#![no_std]
+use soroban_sdk::{contract, contractevent, contractimpl, Address, Env, String};
+
+mod error;
+mod types;
+
+use error::QuidError;
+use types::{Attestation, DataKey};
+
+#[contractevent(topics = ["attestation", "issued"])]
+pub struct AttestationIssuedEvent {
+    pub attestation_id: u64,
+    pub issuer: Address,
+    pub subject: Address,
+}
+
+#[contractevent(topics = ["attestation", "revoked"], data_format = "single-value")]
+pub struct AttestationRevokedEvent {
+    pub attestation_id: u64,
+}
+
+#[contract]
+pub struct QuidReputationContract;
+
+#[contractimpl]
+impl QuidReputationContract {
+    /// Bootstrap admin for the contract
+    pub fn bootstrap_admin(env: Env, admin: Address) -> Result<(), QuidError> {
+        // Only allow setting admin if not already set
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Admin)
+        {
+            return Err(QuidError::NotAuthorized);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Admin, &admin);
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Admin, 5184000, 5184000);
+
+        Ok(())
+    }
+
+    /// Get the current admin
+    pub fn get_admin(env: Env) -> Result<Address, QuidError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(QuidError::AdminNotSet)
+    }
+
+    /// Issue an attestation for a subject
+    pub fn issue_attestation(
+        env: Env,
+        issuer: Address,
+        subject: Address,
+        kind: String,
+        label: String,
+        metadata_cid: Option<String>,
+        expires_at: Option<u64>,
+    ) -> Result<u64, QuidError> {
+        // Require issuer auth
+        issuer.require_auth();
+
+        // Validate label is not empty
+        if label.is_empty() {
+            return Err(QuidError::InvalidLabel);
+        }
+
+        // Validate expiry time if provided
+        if let Some(expiry) = expires_at {
+            let now = env.ledger().timestamp();
+            if expiry <= now {
+                return Err(QuidError::InvalidExpiryTime);
+            }
+        }
+
+        // Get the next attestation id
+        let attestation_id = Self::get_next_attestation_id(&env);
+
+        let issued_at = env.ledger().timestamp();
+
+        let attestation = Attestation {
+            id: attestation_id,
+            issuer: issuer.clone(),
+            subject: subject.clone(),
+            kind,
+            label,
+            metadata_cid,
+            issued_at,
+            expires_at,
+            revoked: false,
+        };
+
+        // Store the attestation
+        env.storage()
+            .persistent()
+            .set(&DataKey::Attestation(attestation_id), &attestation);
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Attestation(attestation_id), 5184000, 5184000);
+
+        // Publish AttestationIssuedEvent
+        AttestationIssuedEvent {
+            attestation_id,
+            issuer,
+            subject,
+        }
+        .publish(&env);
+
+        Ok(attestation_id)
+    }
+
+    /// Get an attestation by id
+    pub fn get_attestation(env: Env, attestation_id: u64) -> Result<Attestation, QuidError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Attestation(attestation_id))
+            .ok_or(QuidError::AttestationNotFound)
+    }
+
+    /// Revoke an attestation
+    pub fn revoke_attestation(env: Env, attestation_id: u64) -> Result<(), QuidError> {
+        let mut attestation = Self::get_attestation(env.clone(), attestation_id)?;
+
+        // Require issuer auth
+        attestation.issuer.require_auth();
+
+        // Check if already revoked
+        if attestation.revoked {
+            return Err(QuidError::AlreadyRevoked);
+        }
+
+        // Mark as revoked
+        attestation.revoked = true;
+
+        // Store updated attestation
+        env.storage()
+            .persistent()
+            .set(&DataKey::Attestation(attestation_id), &attestation);
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Attestation(attestation_id), 5184000, 5184000);
+
+        // Publish AttestationRevokedEvent
+        AttestationRevokedEvent { attestation_id }.publish(&env);
+
+        Ok(())
+    }
+
+    /// Get the next attestation id (internal helper)
+    fn get_next_attestation_id(env: &Env) -> u64 {
+        let current: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AttestationCount)
+            .unwrap_or(0);
+
+        let next_id = current + 1;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::AttestationCount, &next_id);
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::AttestationCount, 5184000, 5184000);
+
+        next_id
+    }
+}

--- a/quid-contract/contracts/quid-reputation/src/lib.rs
+++ b/quid-contract/contracts/quid-reputation/src/lib.rs
@@ -2,10 +2,8 @@
 
 use soroban_sdk::{contract, contractevent, contractimpl, Address, Env, String};
 
-
 mod error;
 mod types;
-
 
 use error::QuidError;
 use types::{Attestation, DataKey};
@@ -22,13 +20,11 @@ pub struct AttestationRevokedEvent {
     pub attestation_id: u64,
 }
 
-
 #[contract]
 pub struct QuidReputationContract;
 
 #[contractimpl]
 impl QuidReputationContract {
-
     /// Bootstrap admin for the contract
     pub fn bootstrap_admin(env: Env, admin: Address) -> Result<(), QuidError> {
         // Only allow setting admin if not already set
@@ -83,7 +79,6 @@ impl QuidReputationContract {
 
         // Get the next attestation id
         let attestation_id = Self::get_next_attestation_id(&env);
-
 
         let issued_at = env.ledger().timestamp();
 

--- a/quid-contract/contracts/quid-reputation/src/lib.rs
+++ b/quid-contract/contracts/quid-reputation/src/lib.rs
@@ -50,12 +50,10 @@ impl QuidReputationContract {
     }
 
     /// Issue an attestation for a subject
-
     pub fn issue_attestation(
         env: Env,
         issuer: Address,
         subject: Address,
-
         kind: String,
         label: String,
         metadata_cid: Option<String>,
@@ -84,7 +82,6 @@ impl QuidReputationContract {
 
         let attestation = Attestation {
             id: attestation_id,
-
             issuer: issuer.clone(),
             subject: subject.clone(),
             kind,

--- a/quid-contract/contracts/quid-reputation/src/test.rs
+++ b/quid-contract/contracts/quid-reputation/src/test.rs
@@ -1,0 +1,143 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_bootstrap_admin() {
+    let env = Env::default();
+    let admin = Address::random(&env);
+
+    let result = QuidReputationContract::bootstrap_admin(env.clone(), admin.clone());
+
+    assert!(result.is_ok());
+
+    let retrieved_admin = QuidReputationContract::get_admin(env).unwrap();
+    assert_eq!(retrieved_admin, admin);
+}
+
+#[test]
+fn test_bootstrap_admin_twice_fails() {
+    let env = Env::default();
+    let admin1 = Address::random(&env);
+    let admin2 = Address::random(&env);
+
+    QuidReputationContract::bootstrap_admin(env.clone(), admin1).unwrap();
+    let result = QuidReputationContract::bootstrap_admin(env, admin2);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_issue_attestation() {
+    let env = Env::default();
+    let issuer = Address::random(&env);
+    let subject = Address::random(&env);
+
+    let attestation_id = QuidReputationContract::issue_attestation(
+        env.clone(),
+        issuer.clone(),
+        subject.clone(),
+        String::from_slice(&env, "contributor"),
+        String::from_slice(&env, "Active contributor"),
+        Some(String::from_slice(&env, "QmExample123")),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(attestation_id, 1);
+
+    let attestation = QuidReputationContract::get_attestation(env, attestation_id).unwrap();
+    assert_eq!(attestation.issuer, issuer);
+    assert_eq!(attestation.subject, subject);
+    assert_eq!(attestation.revoked, false);
+}
+
+#[test]
+fn test_issue_attestation_with_expiry() {
+    let env = Env::default();
+    let issuer = Address::random(&env);
+    let subject = Address::random(&env);
+
+    let now = env.ledger().timestamp();
+    let expiry = now + 86400; // 1 day from now
+
+    let attestation_id = QuidReputationContract::issue_attestation(
+        env.clone(),
+        issuer.clone(),
+        subject.clone(),
+        String::from_slice(&env, "expert"),
+        String::from_slice(&env, "Expert reviewer"),
+        None,
+        Some(expiry),
+    )
+    .unwrap();
+
+    let attestation = QuidReputationContract::get_attestation(env, attestation_id).unwrap();
+    assert_eq!(attestation.expires_at, Some(expiry));
+}
+
+#[test]
+fn test_revoke_attestation() {
+    let env = Env::default();
+    let issuer = Address::random(&env);
+    let subject = Address::random(&env);
+
+    let attestation_id = QuidReputationContract::issue_attestation(
+        env.clone(),
+        issuer.clone(),
+        subject.clone(),
+        String::from_slice(&env, "contributor"),
+        String::from_slice(&env, "Active contributor"),
+        None,
+        None,
+    )
+    .unwrap();
+
+    let result = QuidReputationContract::revoke_attestation(env.clone(), attestation_id);
+    assert!(result.is_ok());
+
+    let attestation = QuidReputationContract::get_attestation(env, attestation_id).unwrap();
+    assert_eq!(attestation.revoked, true);
+}
+
+#[test]
+fn test_empty_label_fails() {
+    let env = Env::default();
+    let issuer = Address::random(&env);
+    let subject = Address::random(&env);
+
+    let result = QuidReputationContract::issue_attestation(
+        env,
+        issuer,
+        subject,
+        String::from_slice(&env, "contributor"),
+        String::from_slice(&env, ""),
+        None,
+        None,
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_invalid_expiry_time_fails() {
+    let env = Env::default();
+    let issuer = Address::random(&env);
+    let subject = Address::random(&env);
+
+    let now = env.ledger().timestamp();
+    let past_expiry = now - 1000; // In the past
+
+    let result = QuidReputationContract::issue_attestation(
+        env,
+        issuer,
+        subject,
+        String::from_slice(&env, "contributor"),
+        String::from_slice(&env, "Active contributor"),
+        None,
+        Some(past_expiry),
+    );
+
+    assert!(result.is_err());
+}

--- a/quid-contract/contracts/quid-reputation/src/types.rs
+++ b/quid-contract/contracts/quid-reputation/src/types.rs
@@ -18,7 +18,6 @@ pub enum DataKey {
     Attestation(u64),
     AttestationCount,
     Admin,
-
 }
 
 #[contracttype]
@@ -26,5 +25,4 @@ pub enum AttestationKind {
     Contributor,
     Expert,
     Reviewer,
-
 }

--- a/quid-contract/contracts/quid-reputation/src/types.rs
+++ b/quid-contract/contracts/quid-reputation/src/types.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::{contracttype, Address, String};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attestation {
+    pub id: u64,
+    pub issuer: Address,
+    pub subject: Address,
+    pub kind: String,
+    pub label: String,
+    pub metadata_cid: Option<String>,
+    pub issued_at: u64,
+    pub expires_at: Option<u64>,
+    pub revoked: bool,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Attestation(u64),
+    AttestationCount,
+    Admin,
+}
+
+#[contracttype]
+pub enum AttestationKind {
+    Contributor,
+    Expert,
+    Reviewer,
+}


### PR DESCRIPTION
# feat(contracts): implement issue attestation

## Description
Implement the `issue_attestation` entrypoint for the quid-reputation contract that allows issuers to publish portable contributor attestations with metadata and expiry.

## Changes
- Created new `quid-reputation` contract with Soroban SDK
- Implemented `issue_attestation` entrypoint with:
  - Issuer authentication requirement
  - Incrementing attestation ID counter
  - Attestation record storage with issued_at, optional metadata CID, optional expiry, and revoke state
  - AttestationIssuedEvent publishing
- Added data structures: `Attestation`, `AttestationKind`
- Added error handling and tests

## Acceptance Criteria Met
- ✅ Issuers can create attestations for subjects
- ✅ Attestations store metadata CID, expiry, and revoke state
- ✅ Issuing an attestation increments the attestation counter
- ✅ Contract builds successfully to WebAssembly

## Related Issue
Closes #196

## Testing
```cargo build --target wasm32-unknown-unknown --release``` builds successfully