### PR TITLE
Implement milestone creation and read path for escrow contract

### DIFF
--- a/quid-contract/contracts/quid-milestone-escrow/src/error.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/error.rs
@@ -6,4 +6,5 @@ pub enum MilestoneEscrowError {
     InvalidState = 1,
     InvalidAmount = 2,
     ProgramNotFound = 3,
+    MilestoneNotFound = 4,
 }

--- a/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
@@ -6,7 +6,7 @@ mod error;
 pub mod types;
 
 use error::MilestoneEscrowError;
-use types::{DataKey, MilestoneStatus, Program, ProgramStatus};
+use types::{DataKey, Milestone, MilestoneStatus, Program, ProgramStatus};
 
 #[contractevent(topics = ["program", "created"])]
 pub struct ProgramCreatedEvent {
@@ -19,6 +19,13 @@ pub struct ProgramCreatedEvent {
 pub struct ProgramStatusChangedEvent {
     pub program_id: u64,
     pub status: ProgramStatus,
+}
+
+#[contractevent(topics = ["milestone", "added"])]
+pub struct MilestoneAddedEvent {
+    pub program_id: u64,
+    pub milestone_id: u64,
+    pub amount: i128,
 }
 
 #[contract]
@@ -84,6 +91,75 @@ impl QuidMilestoneEscrowContract {
             .persistent()
             .get(&DataKey::Program(program_id))
             .ok_or(MilestoneEscrowError::ProgramNotFound)
+    }
+
+    pub fn add_milestone(
+        env: Env,
+        program_id: u64,
+        title: String,
+        amount: i128,
+        due_at: u64,
+        metadata_cid: String,
+    ) -> Result<u64, MilestoneEscrowError> {
+        let mut program = Self::get_program(env.clone(), program_id)?;
+        program.sponsor.require_auth();
+
+        if program.status != ProgramStatus::Active {
+            return Err(MilestoneEscrowError::InvalidState);
+        }
+
+        if amount <= 0 {
+            return Err(MilestoneEscrowError::InvalidAmount);
+        }
+
+        let allocated_amount = program
+            .allocated_amount
+            .checked_add(amount)
+            .ok_or(MilestoneEscrowError::InvalidAmount)?;
+        if allocated_amount > program.total_amount {
+            return Err(MilestoneEscrowError::InvalidAmount);
+        }
+
+        let milestone_id = program.milestone_count + 1;
+        let milestone = Milestone {
+            id: milestone_id,
+            program_id,
+            title,
+            amount,
+            due_at,
+            metadata_cid,
+            status: MilestoneStatus::Pending,
+        };
+
+        program.allocated_amount = allocated_amount;
+        program.milestone_count = milestone_id;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Milestone(program_id, milestone_id), &milestone);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Program(program_id), &program);
+
+        MilestoneAddedEvent {
+            program_id,
+            milestone_id,
+            amount,
+        }
+        .publish(&env);
+
+        Ok(milestone_id)
+    }
+
+    pub fn get_milestone(
+        env: Env,
+        program_id: u64,
+        milestone_id: u64,
+    ) -> Result<Milestone, MilestoneEscrowError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Milestone(program_id, milestone_id))
+            .ok_or(MilestoneEscrowError::InvalidState)
     }
 
     pub fn get_program_status(env: Env) -> ProgramStatus {

--- a/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
@@ -159,7 +159,7 @@ impl QuidMilestoneEscrowContract {
         env.storage()
             .persistent()
             .get(&DataKey::Milestone(program_id, milestone_id))
-            .ok_or(MilestoneEscrowError::InvalidState)
+            .ok_or(MilestoneEscrowError::MilestoneNotFound)
     }
 
     pub fn get_program_status(env: Env) -> ProgramStatus {

--- a/quid-contract/contracts/quid-milestone-escrow/src/test.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/test.rs
@@ -86,6 +86,75 @@ fn test_create_program_funds_and_stores_active_program() {
 }
 
 #[test]
+fn test_add_milestone_stores_and_updates_program_totals() {
+    let (env, contract_id, sponsor, token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+    let total_amount = 500;
+    let milestone_amount = 200;
+    let due_at = 1_750_000_000;
+
+    let program_id = client.create_program(
+        &sponsor,
+        &recipient,
+        &token_address,
+        &total_amount,
+        &None,
+        &None,
+    );
+    let milestone_id = client.add_milestone(
+        &program_id,
+        &String::from_str(&env, "Design complete"),
+        &milestone_amount,
+        &due_at,
+        &String::from_str(&env, "QmMilestone"),
+    );
+
+    assert_eq!(milestone_id, 1);
+
+    let program = client.get_program(&program_id);
+    assert_eq!(program.allocated_amount, milestone_amount);
+    assert_eq!(program.milestone_count, 1);
+
+    let milestone = client.get_milestone(&program_id, &milestone_id);
+    assert_eq!(milestone.id, milestone_id);
+    assert_eq!(milestone.program_id, program_id);
+    assert_eq!(milestone.title, String::from_str(&env, "Design complete"));
+    assert_eq!(milestone.amount, milestone_amount);
+    assert_eq!(milestone.due_at, due_at);
+    assert_eq!(
+        milestone.metadata_cid,
+        String::from_str(&env, "QmMilestone")
+    );
+    assert_eq!(milestone.status, MilestoneStatus::Pending);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_add_milestone_rejects_over_allocation() {
+    let (env, contract_id, sponsor, token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+    let total_amount = 500;
+
+    let program_id = client.create_program(
+        &sponsor,
+        &recipient,
+        &token_address,
+        &total_amount,
+        &None,
+        &None,
+    );
+    let _ = client.add_milestone(
+        &program_id,
+        &String::from_str(&env, "Too large"),
+        &501,
+        &1_750_000_000,
+        &String::from_str(&env, "QmMilestone"),
+    );
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #2)")]
 fn test_create_program_rejects_zero_amount() {
     let (env, contract_id, sponsor, token_address) = setup_test_env();

--- a/quid-contract/contracts/quid-milestone-escrow/src/test.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/test.rs
@@ -155,6 +155,15 @@ fn test_add_milestone_rejects_over_allocation() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_get_milestone_not_found() {
+    let (env, contract_id, _sponsor, _token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+
+    let _ = client.get_milestone(&999, &1);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #2)")]
 fn test_create_program_rejects_zero_amount() {
     let (env, contract_id, sponsor, token_address) = setup_test_env();


### PR DESCRIPTION
## Summary
- Added `add_milestone` so sponsors can create milestones for active funded programs
- Validates positive milestone amounts and rejects over-allocation beyond `total_amount`
- Persists milestones, updates `allocated_amount` and `milestone_count`, and publishes `MilestoneAddedEvent`
- Added `get_milestone` to fetch stored milestones by `(program_id, milestone_id)`
- Added `MilestoneNotFound` for missing milestone records

## Testing
- `cargo fmt`
- `cargo test -p quid-milestone-escrow`

Closes #179
Closes #180