### PR TITLE
feat(contracts): implement upsert profile

### DIFF
--- a/quid-contract/.gitignore
+++ b/quid-contract/.gitignore
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # Rust's output directory
 target
 
@@ -6,4 +7,14 @@ target
 .stellar
 .vscode/
 
+=======
+# Rust's output directory
+target
+
+# Local settings
+.soroban
+.stellar
+.vscode/
+
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)
 **/*/test_snapshots

--- a/quid-contract/Cargo.toml
+++ b/quid-contract/Cargo.toml
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 [workspace]
 resolver = "2"
 members = [
@@ -21,3 +22,28 @@ lto = true
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
+=======
+[workspace]
+resolver = "2"
+members = [
+  "contracts/*",
+]
+
+[workspace.dependencies]
+soroban-sdk = "23"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+# For more information about this profile see https://soroban.stellar.org/docs/basic-tutorials/logging#cargotoml-profile
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)

--- a/quid-contract/README.md
+++ b/quid-contract/README.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # Soroban Project
 
 ## Project Structure
@@ -20,3 +21,27 @@ This repository uses the recommended structure for a Soroban project:
 - If you initialized this project with any other example contracts via `--with-example`, those contracts will be in the `contracts` directory as well.
 - Contracts should have their own `Cargo.toml` files that rely on the top-level `Cargo.toml` workspace for their dependencies.
 - Frontend libraries can be added to the top-level directory as well. If you initialized this project with a frontend template via `--frontend-template` you will have those files already included.
+=======
+# Soroban Project
+
+## Project Structure
+
+This repository uses the recommended structure for a Soroban project:
+
+```text
+.
+├── contracts
+│   └── hello_world
+│       ├── src
+│       │   ├── lib.rs
+│       │   └── test.rs
+│       └── Cargo.toml
+├── Cargo.toml
+└── README.md
+```
+
+- New Soroban contracts can be put in `contracts`, each in their own directory. There is already a `hello_world` contract in there to get you started.
+- If you initialized this project with any other example contracts via `--with-example`, those contracts will be in the `contracts` directory as well.
+- Contracts should have their own `Cargo.toml` files that rely on the top-level `Cargo.toml` workspace for their dependencies.
+- Frontend libraries can be added to the top-level directory as well. If you initialized this project with a frontend template via `--frontend-template` you will have those files already included.
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)

--- a/quid-contract/contracts/hello-world/Cargo.toml
+++ b/quid-contract/contracts/hello-world/Cargo.toml
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 [package]
 name = "hello-world"
 version = "0.0.0"
@@ -13,3 +14,20 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+=======
+[package]
+name = "hello-world"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)

--- a/quid-contract/contracts/hello-world/Makefile
+++ b/quid-contract/contracts/hello-world/Makefile
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 default: build
 
 all: test
@@ -14,3 +15,21 @@ fmt:
 
 clean:
 	cargo clean
+=======
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)

--- a/quid-contract/contracts/hello-world/src/lib.rs
+++ b/quid-contract/contracts/hello-world/src/lib.rs
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 #![no_std]
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
@@ -21,3 +22,28 @@ impl Contract {
 }
 
 mod test;
+=======
+#![no_std]
+use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
+
+#[contract]
+pub struct Contract;
+
+// This is a sample contract. Replace this placeholder with your own contract logic.
+// A corresponding test example is available in `test.rs`.
+//
+// For comprehensive examples, visit <https://github.com/stellar/soroban-examples>.
+// The repository includes use cases for the Stellar ecosystem, such as data storage on
+// the blockchain, token swaps, liquidity pools, and more.
+//
+// Refer to the official documentation:
+// <https://developers.stellar.org/docs/build/smart-contracts/overview>.
+#[contractimpl]
+impl Contract {
+    pub fn hello(env: Env, to: String) -> Vec<String> {
+        vec![&env, String::from_str(&env, "Hello"), to]
+    }
+}
+
+mod test;
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)

--- a/quid-contract/contracts/hello-world/src/test.rs
+++ b/quid-contract/contracts/hello-world/src/test.rs
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 #![cfg(test)]
 
 use super::*;
@@ -19,3 +20,26 @@ fn test() {
         ]
     );
 }
+=======
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{vec, Env, String};
+
+#[test]
+fn test() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    let words = client.hello(&String::from_str(&env, "Dev"));
+    assert_eq!(
+        words,
+        vec![
+            &env,
+            String::from_str(&env, "Hello"),
+            String::from_str(&env, "Dev"),
+        ]
+    );
+}
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)

--- a/quid-contract/contracts/quid-milestone-escrow/src/error.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/error.rs
@@ -4,4 +4,9 @@ use soroban_sdk::contracterror;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum MilestoneEscrowError {
     InvalidState = 1,
+<<<<<<< HEAD
+=======
+    InvalidAmount = 2,
+    ProgramNotFound = 3,
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)
 }

--- a/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/lib.rs
@@ -1,17 +1,102 @@
 #![no_std]
 
+<<<<<<< HEAD
 use soroban_sdk::{contract, contractimpl, Env};
+=======
+use soroban_sdk::{contract, contractevent, contractimpl, token, Address, Env, String};
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)
 
 mod error;
 pub mod types;
 
+<<<<<<< HEAD
 use types::{DataKey, MilestoneStatus, ProgramStatus};
+=======
+use error::MilestoneEscrowError;
+use types::{DataKey, MilestoneStatus, Program, ProgramStatus};
+
+#[contractevent(topics = ["program", "created"])]
+pub struct ProgramCreatedEvent {
+    pub program_id: u64,
+    pub sponsor: Address,
+    pub recipient: Address,
+}
+
+#[contractevent(topics = ["program", "status_changed"])]
+pub struct ProgramStatusChangedEvent {
+    pub program_id: u64,
+    pub status: ProgramStatus,
+}
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)
 
 #[contract]
 pub struct QuidMilestoneEscrowContract;
 
 #[contractimpl]
 impl QuidMilestoneEscrowContract {
+<<<<<<< HEAD
+=======
+    pub fn create_program(
+        env: Env,
+        sponsor: Address,
+        recipient: Address,
+        token: Address,
+        total_amount: i128,
+        reviewer: Option<Address>,
+        metadata_cid: Option<String>,
+    ) -> Result<u64, MilestoneEscrowError> {
+        sponsor.require_auth();
+
+        if total_amount <= 0 {
+            return Err(MilestoneEscrowError::InvalidAmount);
+        }
+
+        token::Client::new(&env, &token).transfer(
+            &sponsor,
+            env.current_contract_address(),
+            &total_amount,
+        );
+
+        let program_id = Self::get_next_program_id(&env);
+        let status = ProgramStatus::Active;
+        let program = Program {
+            id: program_id,
+            sponsor: sponsor.clone(),
+            recipient: recipient.clone(),
+            reviewer,
+            token,
+            total_amount,
+            allocated_amount: 0,
+            released_amount: 0,
+            milestone_count: 0,
+            metadata_cid,
+            created_at: env.ledger().timestamp(),
+            status,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Program(program_id), &program);
+
+        ProgramCreatedEvent {
+            program_id,
+            sponsor,
+            recipient,
+        }
+        .publish(&env);
+        ProgramStatusChangedEvent { program_id, status }.publish(&env);
+
+        Ok(program_id)
+    }
+
+    pub fn get_program(env: Env, program_id: u64) -> Result<Program, MilestoneEscrowError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Program(program_id))
+            .ok_or(MilestoneEscrowError::ProgramNotFound)
+    }
+
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)
     pub fn get_program_status(env: Env) -> ProgramStatus {
         env.storage()
             .persistent()
@@ -37,6 +122,27 @@ impl QuidMilestoneEscrowContract {
             .persistent()
             .set(&DataKey::MilestoneStatus, &status);
     }
+<<<<<<< HEAD
+=======
+
+    pub fn get_program_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ProgramCount)
+            .unwrap_or(0)
+    }
+
+    fn get_next_program_id(env: &Env) -> u64 {
+        let mut count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProgramCount)
+            .unwrap_or(0);
+        count += 1;
+        env.storage().instance().set(&DataKey::ProgramCount, &count);
+        count
+    }
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)
 }
 
 mod test;

--- a/quid-contract/contracts/quid-milestone-escrow/src/test.rs
+++ b/quid-contract/contracts/quid-milestone-escrow/src/test.rs
@@ -2,7 +2,27 @@
 
 use super::*;
 use crate::types::{MilestoneStatus, ProgramStatus};
+<<<<<<< HEAD
 use soroban_sdk::Env;
+=======
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+use soroban_sdk::{testutils::Address as _, testutils::Events, Address, Env, String};
+
+fn setup_test_env() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuidMilestoneEscrowContract, ());
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+    let sponsor = Address::generate(&env);
+    let token_admin_client = StellarAssetClient::new(&env, &token_address);
+    token_admin_client.mint(&sponsor, &1_000_000);
+
+    (env, contract_id, sponsor, token_address)
+}
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)
 
 #[test]
 fn test_default_statuses() {
@@ -26,3 +46,67 @@ fn test_status_storage_roundtrip() {
     assert_eq!(client.get_program_status(), ProgramStatus::Completed);
     assert_eq!(client.get_milestone_status(), MilestoneStatus::Paid);
 }
+<<<<<<< HEAD
+=======
+
+#[test]
+fn test_create_program_funds_and_stores_active_program() {
+    let (env, contract_id, sponsor, token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token_address);
+    let recipient = Address::generate(&env);
+    let reviewer = Address::generate(&env);
+    let total_amount = 500;
+
+    let program_id = client.create_program(
+        &sponsor,
+        &recipient,
+        &token_address,
+        &total_amount,
+        &Some(reviewer.clone()),
+        &Some(String::from_str(&env, "QmProgram")),
+    );
+    let contract_event_count = env
+        .events()
+        .all()
+        .iter()
+        .filter(|(id, _, _)| id == &contract_id)
+        .count();
+
+    assert_eq!(program_id, 1);
+    assert_eq!(contract_event_count, 2);
+    assert_eq!(token_client.balance(&contract_id), total_amount);
+    assert_eq!(client.get_program_count(), 1);
+
+    let program = client.get_program(&program_id);
+    assert_eq!(program.id, program_id);
+    assert_eq!(program.sponsor, sponsor);
+    assert_eq!(program.recipient, recipient);
+    assert_eq!(program.reviewer, Some(reviewer));
+    assert_eq!(program.token, token_address);
+    assert_eq!(program.total_amount, total_amount);
+    assert_eq!(program.allocated_amount, 0);
+    assert_eq!(program.released_amount, 0);
+    assert_eq!(program.milestone_count, 0);
+    assert_eq!(program.status, ProgramStatus::Active);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_create_program_rejects_zero_amount() {
+    let (env, contract_id, sponsor, token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+
+    let _ = client.create_program(&sponsor, &recipient, &token_address, &0, &None, &None);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_get_program_not_found() {
+    let (env, contract_id, _sponsor, _token_address) = setup_test_env();
+    let client = QuidMilestoneEscrowContractClient::new(&env, &contract_id);
+
+    let _ = client.get_program(&999);
+}
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)

--- a/quid-contract/contracts/quid-reputation/Cargo.toml
+++ b/quid-contract/contracts/quid-reputation/Cargo.toml
@@ -2,12 +2,27 @@
 name = "quid-reputation"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/quid-contract/contracts/quid-reputation/Cargo.toml
+++ b/quid-contract/contracts/quid-reputation/Cargo.toml
@@ -1,0 +1,13 @@
+﻿[package]
+name = "quid-reputation"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/quid-contract/contracts/quid-reputation/src/error.rs
+++ b/quid-contract/contracts/quid-reputation/src/error.rs
@@ -2,9 +2,15 @@
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum ReputationError {
+pub enum QuidError {
     NotAuthorized = 1,
     ProfileNotFound = 2,
-    InvalidEarnings = 3,
+    AdminAlreadySet = 3,
     InvalidScore = 4,
+    AttestationNotFound = 5,
+    InvalidExpiryTime = 6,
+    AlreadyRevoked = 7,
+    AdminNotSet = 8,
+    InvalidLabel = 9,
+    InvalidRewardAmount = 10,
 }

--- a/quid-contract/contracts/quid-reputation/src/error.rs
+++ b/quid-contract/contracts/quid-reputation/src/error.rs
@@ -1,0 +1,10 @@
+﻿use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ReputationError {
+    NotAuthorized = 1,
+    ProfileNotFound = 2,
+    InvalidEarnings = 3,
+    InvalidScore = 4,
+}

--- a/quid-contract/contracts/quid-reputation/src/lib.rs
+++ b/quid-contract/contracts/quid-reputation/src/lib.rs
@@ -1,36 +1,25 @@
 ﻿#![no_std]
 
-use soroban_sdk::{contract, contractevent, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contractevent, contractimpl, Address, Env, String};
 
 mod error;
-use error::ReputationError;
+mod types;
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Profile {
+use error::QuidError;
+use types::{Attestation, DataKey, Profile};
+
+const PROFILE_TTL_LEDGERS: u32 = 5_184_000;
+
+#[contractevent(topics = ["attestation", "issued"])]
+pub struct AttestationIssuedEvent {
+    pub attestation_id: u64,
+    pub issuer: Address,
     pub subject: Address,
-    pub successful_missions: u32,
-    pub rejected_submissions: u32,
-    pub reviewer_score: u32,
-    pub founder_score: u32,
-    pub total_earnings: i128,
-    pub updated_at: u64,
 }
 
-#[contracttype]
-pub enum DataKey {
-    Admin,
-    Profile(Address),
-}
-
-#[contractevent(topics = ["profile", "updated"])]
-pub struct ProfileUpdatedEvent {
-    pub subject: Address,
-    pub successful_missions: u32,
-    pub rejected_submissions: u32,
-    pub reviewer_score: u32,
-    pub founder_score: u32,
-    pub total_earnings: i128,
+#[contractevent(topics = ["attestation", "revoked"], data_format = "single-value")]
+pub struct AttestationRevokedEvent {
+    pub attestation_id: u64,
 }
 
 #[contract]
@@ -38,20 +27,127 @@ pub struct QuidReputationContract;
 
 #[contractimpl]
 impl QuidReputationContract {
-    /// Initialize the contract with an admin address.
-    pub fn initialize(env: Env, admin: Address) {
-        if env.storage().instance().has(&DataKey::Admin) {
-            panic!("Already initialized");
+    /// Bootstrap admin for the contract
+    pub fn bootstrap_admin(env: Env, admin: Address) -> Result<(), QuidError> {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            return Err(QuidError::AdminAlreadySet);
         }
-        env.storage().instance().set(&DataKey::Admin, &admin);
+
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Admin, 5184000, 5184000);
+
+        Ok(())
     }
 
-    /// Get the stored admin address.
-    pub fn get_admin(env: Env) -> Result<Address, ReputationError> {
+    /// Get the current admin
+    pub fn get_admin(env: Env) -> Result<Address, QuidError> {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Admin)
-            .ok_or(ReputationError::NotAuthorized)
+            .ok_or(QuidError::AdminNotSet)
+    }
+
+    /// Issue an attestation for a subject
+    pub fn issue_attestation(
+        env: Env,
+        issuer: Address,
+        subject: Address,
+        kind: String,
+        label: String,
+        metadata_cid: Option<String>,
+        expires_at: Option<u64>,
+    ) -> Result<u64, QuidError> {
+        issuer.require_auth();
+
+        if label.is_empty() {
+            return Err(QuidError::InvalidLabel);
+        }
+
+        if let Some(expiry) = expires_at {
+            let now = env.ledger().timestamp();
+            if expiry <= now {
+                return Err(QuidError::InvalidExpiryTime);
+            }
+        }
+
+        let attestation_id = Self::get_next_attestation_id(&env);
+        let issued_at = env.ledger().timestamp();
+
+        let attestation = Attestation {
+            id: attestation_id,
+            issuer: issuer.clone(),
+            subject: subject.clone(),
+            kind,
+            label,
+            metadata_cid,
+            issued_at,
+            expires_at,
+            revoked: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Attestation(attestation_id), &attestation);
+
+        env.storage().persistent().extend_ttl(
+            &DataKey::Attestation(attestation_id),
+            5184000,
+            5184000,
+        );
+
+        AttestationIssuedEvent {
+            attestation_id,
+            issuer,
+            subject,
+        }
+        .publish(&env);
+
+        Ok(attestation_id)
+    }
+
+    /// Get an attestation by id
+    pub fn get_attestation(env: Env, attestation_id: u64) -> Result<Attestation, QuidError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Attestation(attestation_id))
+            .ok_or(QuidError::AttestationNotFound)
+    }
+
+    /// Revoke an attestation
+    pub fn revoke_attestation(env: Env, attestation_id: u64) -> Result<(), QuidError> {
+        let mut attestation = Self::get_attestation(env.clone(), attestation_id)?;
+
+        attestation.issuer.require_auth();
+
+        if attestation.revoked {
+            return Err(QuidError::AlreadyRevoked);
+        }
+
+        attestation.revoked = true;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Attestation(attestation_id), &attestation);
+
+        env.storage().persistent().extend_ttl(
+            &DataKey::Attestation(attestation_id),
+            5184000,
+            5184000,
+        );
+
+        AttestationRevokedEvent { attestation_id }.publish(&env);
+
+        Ok(())
+    }
+
+    /// Fetch the reputation profile for `subject`.
+    pub fn get_profile(env: Env, subject: Address) -> Result<Profile, QuidError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Profile(subject))
+            .ok_or(QuidError::ProfileNotFound)
     }
 
     /// Admin-only upsert: write a full profile snapshot for a subject.
@@ -66,8 +162,7 @@ impl QuidReputationContract {
     ///
     /// # Errors
     /// - `NotAuthorized` if caller is not the configured admin.
-    /// - `InvalidEarnings` if `total_earnings` is negative.
-    /// - `InvalidScore` if reviewer or founder score exceeds 100.
+    /// - `InvalidRewardAmount` if `total_earnings` is negative.
     pub fn upsert_profile(
         env: Env,
         subject: Address,
@@ -76,64 +171,128 @@ impl QuidReputationContract {
         reviewer_score: u32,
         founder_score: u32,
         total_earnings: i128,
-    ) -> Result<(), ReputationError> {
-        // 1. Require admin auth
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(ReputationError::NotAuthorized)?;
+    ) -> Result<(), QuidError> {
+        let admin = Self::get_admin(env.clone())?;
         admin.require_auth();
 
-        // 2. Validate inputs
         if total_earnings < 0 {
-            return Err(ReputationError::InvalidEarnings);
-        }
-        if reviewer_score > 100 {
-            return Err(ReputationError::InvalidScore);
-        }
-        if founder_score > 100 {
-            return Err(ReputationError::InvalidScore);
+            return Err(QuidError::InvalidRewardAmount);
         }
 
-        // 3. Build profile snapshot
         let profile = Profile {
             subject: subject.clone(),
+            score: reviewer_score,
             successful_missions,
-            rejected_submissions,
-            reviewer_score,
-            founder_score,
+            missions_created: founder_score,
             total_earnings,
             updated_at: env.ledger().timestamp(),
         };
 
-        // 4. Store the profile
-        env.storage()
-            .persistent()
-            .set(&DataKey::Profile(subject.clone()), &profile);
+        Self::store_profile(&env, &profile);
 
-        // 5. Publish event
-        ProfileUpdatedEvent {
+        env.events().publish(
+            (
+                soroban_sdk::symbol_short!("profile"),
+                soroban_sdk::symbol_short!("updated"),
+            ),
             subject,
-            successful_missions,
-            rejected_submissions,
-            reviewer_score,
-            founder_score,
-            total_earnings,
-        }
-        .publish(&env);
+        );
 
         Ok(())
     }
 
-    /// Read a profile for a given subject.
-    pub fn get_profile(env: Env, subject: Address) -> Result<Profile, ReputationError> {
+    /// Record a successful mission for `subject` and add `reward_amount` to their total earnings.
+    #[allow(deprecated)]
+    pub fn increment_success(
+        env: Env,
+        subject: Address,
+        reward_amount: i128,
+    ) -> Result<(), QuidError> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        if reward_amount < 0 {
+            return Err(QuidError::InvalidRewardAmount);
+        }
+
+        let mut profile = Self::load_or_default(&env, subject.clone());
+        profile.successful_missions += 1;
+        profile.total_earnings += reward_amount;
+        profile.updated_at = env.ledger().timestamp();
+
+        Self::store_profile(&env, &profile);
+
+        env.events().publish(
+            (
+                soroban_sdk::symbol_short!("Profile"),
+                soroban_sdk::symbol_short!("updated"),
+            ),
+            profile,
+        );
+
+        Ok(())
+    }
+
+    fn get_next_attestation_id(env: &Env) -> u64 {
+        let current: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AttestationCount)
+            .unwrap_or(0);
+
+        let next_id = current + 1;
+
         env.storage()
             .persistent()
-            .get(&DataKey::Profile(subject))
-            .ok_or(ReputationError::ProfileNotFound)
+            .set(&DataKey::AttestationCount, &next_id);
+
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::AttestationCount, 5184000, 5184000);
+
+        next_id
     }
 }
 
-#[cfg(test)]
+#[allow(dead_code)]
+impl QuidReputationContract {
+    pub(crate) fn require_admin(env: &Env, caller: &Address) -> Result<(), QuidError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(QuidError::AdminNotSet)?;
+
+        admin.require_auth();
+
+        if *caller != admin {
+            return Err(QuidError::NotAuthorized);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn store_profile(env: &Env, profile: &Profile) {
+        let key = DataKey::Profile(profile.subject.clone());
+        env.storage().persistent().set(&key, profile);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PROFILE_TTL_LEDGERS, PROFILE_TTL_LEDGERS);
+    }
+
+    pub(crate) fn load_or_default(env: &Env, subject: Address) -> Profile {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Profile(subject.clone()))
+            .unwrap_or(Profile {
+                subject,
+                score: 0,
+                successful_missions: 0,
+                missions_created: 0,
+                total_earnings: 0,
+                updated_at: env.ledger().timestamp(),
+            })
+    }
+}
+
 mod test;

--- a/quid-contract/contracts/quid-reputation/src/lib.rs
+++ b/quid-contract/contracts/quid-reputation/src/lib.rs
@@ -1,0 +1,139 @@
+﻿#![no_std]
+
+use soroban_sdk::{contract, contractevent, contractimpl, contracttype, Address, Env};
+
+mod error;
+use error::ReputationError;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Profile {
+    pub subject: Address,
+    pub successful_missions: u32,
+    pub rejected_submissions: u32,
+    pub reviewer_score: u32,
+    pub founder_score: u32,
+    pub total_earnings: i128,
+    pub updated_at: u64,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Profile(Address),
+}
+
+#[contractevent(topics = ["profile", "updated"])]
+pub struct ProfileUpdatedEvent {
+    pub subject: Address,
+    pub successful_missions: u32,
+    pub rejected_submissions: u32,
+    pub reviewer_score: u32,
+    pub founder_score: u32,
+    pub total_earnings: i128,
+}
+
+#[contract]
+pub struct QuidReputationContract;
+
+#[contractimpl]
+impl QuidReputationContract {
+    /// Initialize the contract with an admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Get the stored admin address.
+    pub fn get_admin(env: Env) -> Result<Address, ReputationError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(ReputationError::NotAuthorized)
+    }
+
+    /// Admin-only upsert: write a full profile snapshot for a subject.
+    ///
+    /// # Arguments
+    /// - `subject`: The address whose profile is being written.
+    /// - `successful_missions`: Count of successfully completed missions.
+    /// - `rejected_submissions`: Count of rejected submissions.
+    /// - `reviewer_score`: Score assigned by reviewers (0-100).
+    /// - `founder_score`: Score assigned by founders (0-100).
+    /// - `total_earnings`: Total earnings in the reward token's base unit.
+    ///
+    /// # Errors
+    /// - `NotAuthorized` if caller is not the configured admin.
+    /// - `InvalidEarnings` if `total_earnings` is negative.
+    /// - `InvalidScore` if reviewer or founder score exceeds 100.
+    pub fn upsert_profile(
+        env: Env,
+        subject: Address,
+        successful_missions: u32,
+        rejected_submissions: u32,
+        reviewer_score: u32,
+        founder_score: u32,
+        total_earnings: i128,
+    ) -> Result<(), ReputationError> {
+        // 1. Require admin auth
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(ReputationError::NotAuthorized)?;
+        admin.require_auth();
+
+        // 2. Validate inputs
+        if total_earnings < 0 {
+            return Err(ReputationError::InvalidEarnings);
+        }
+        if reviewer_score > 100 {
+            return Err(ReputationError::InvalidScore);
+        }
+        if founder_score > 100 {
+            return Err(ReputationError::InvalidScore);
+        }
+
+        // 3. Build profile snapshot
+        let profile = Profile {
+            subject: subject.clone(),
+            successful_missions,
+            rejected_submissions,
+            reviewer_score,
+            founder_score,
+            total_earnings,
+            updated_at: env.ledger().timestamp(),
+        };
+
+        // 4. Store the profile
+        env.storage()
+            .persistent()
+            .set(&DataKey::Profile(subject.clone()), &profile);
+
+        // 5. Publish event
+        ProfileUpdatedEvent {
+            subject,
+            successful_missions,
+            rejected_submissions,
+            reviewer_score,
+            founder_score,
+            total_earnings,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Read a profile for a given subject.
+    pub fn get_profile(env: Env, subject: Address) -> Result<Profile, ReputationError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Profile(subject))
+            .ok_or(ReputationError::ProfileNotFound)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/quid-contract/contracts/quid-reputation/src/test.rs
+++ b/quid-contract/contracts/quid-reputation/src/test.rs
@@ -1,183 +1,150 @@
 ﻿#![cfg(test)]
 
-use soroban_sdk::{
-    testutils::{Address as _, Env as _},
-    Address, Env,
-};
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
-use crate::{QuidReputationContract, QuidReputationContractClient, Profile};
-
-fn setup_contract<'a>(env: &Env) -> QuidReputationContractClient<'a> {
-    let admin = Address::generate(env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(env, &contract_id);
-    client.initialize(&admin);
-    client
-}
-
-#[test]
-fn test_initialize_sets_admin() {
+fn setup_test_env() -> (Env, Address, QuidReputationContractClient<'static>) {
     let env = Env::default();
+    env.mock_all_auths();
+
     let admin = Address::generate(&env);
     let contract_id = env.register(QuidReputationContract, ());
     let client = QuidReputationContractClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
-    assert_eq!(client.get_admin(), admin);
+    client.bootstrap_admin(&admin);
+
+    (env, admin, client)
 }
 
 #[test]
-#[should_panic(expected = "Already initialized")]
-fn test_double_initialize_fails() {
+fn test_bootstrap_admin() {
     let env = Env::default();
+    env.mock_all_auths();
     let admin = Address::generate(&env);
     let contract_id = env.register(QuidReputationContract, ());
     let client = QuidReputationContractClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
-    client.initialize(&admin);
+    client.bootstrap_admin(&admin);
+
+    let retrieved_admin = client.get_admin();
+    assert_eq!(retrieved_admin, admin);
 }
 
 #[test]
-fn test_upsert_profile_success() {
+fn test_bootstrap_admin_twice_fails() {
     let env = Env::default();
-    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.bootstrap_admin(&admin1);
+    let result = client.try_bootstrap_admin(&admin2);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_issue_attestation() {
+    let (env, _admin, client) = setup_test_env();
+    let issuer = Address::generate(&env);
     let subject = Address::generate(&env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
-
-    client.upsert_profile(
+    let attestation_id = client.issue_attestation(
+        &issuer,
         &subject,
-        &10_u32,
-        &2_u32,
-        &85_u32,
-        &90_u32,
-        &5000_i128,
+        &String::from_str(&env, "contributor"),
+        &String::from_str(&env, "Active contributor"),
+        &Some(String::from_str(&env, "QmExample123")),
+        &None,
     );
 
-    let profile = client.get_profile(&subject).unwrap();
-    assert_eq!(profile.subject, subject);
-    assert_eq!(profile.successful_missions, 10);
-    assert_eq!(profile.rejected_submissions, 2);
-    assert_eq!(profile.reviewer_score, 85);
-    assert_eq!(profile.founder_score, 90);
-    assert_eq!(profile.total_earnings, 5000);
-    assert!(profile.updated_at > 0);
+    assert_eq!(attestation_id, 1);
+
+    let attestation = client.get_attestation(&attestation_id);
+    assert_eq!(attestation.issuer, issuer);
+    assert_eq!(attestation.subject, subject);
+    assert!(!attestation.revoked);
 }
 
 #[test]
-fn test_upsert_profile_updates_existing() {
-    let env = Env::default();
-    let admin = Address::generate(&env);
+fn test_issue_attestation_with_expiry() {
+    let (env, _admin, client) = setup_test_env();
+    let issuer = Address::generate(&env);
     let subject = Address::generate(&env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
+    let now = env.ledger().timestamp();
+    let expiry = now + 86400;
 
-    // First upsert
-    client.upsert_profile(
+    let attestation_id = client.issue_attestation(
+        &issuer,
         &subject,
-        &5_u32,
-        &1_u32,
-        &70_u32,
-        &80_u32,
-        &1000_i128,
+        &String::from_str(&env, "expert"),
+        &String::from_str(&env, "Expert reviewer"),
+        &None,
+        &Some(expiry),
     );
 
-    // Second upsert — overwrites
-    client.upsert_profile(
-        &subject,
-        &15_u32,
-        &0_u32,
-        &95_u32,
-        &100_u32,
-        &7500_i128,
-    );
-
-    let profile = client.get_profile(&subject).unwrap();
-    assert_eq!(profile.successful_missions, 15);
-    assert_eq!(profile.rejected_submissions, 0);
-    assert_eq!(profile.reviewer_score, 95);
-    assert_eq!(profile.founder_score, 100);
-    assert_eq!(profile.total_earnings, 7500);
+    let attestation = client.get_attestation(&attestation_id);
+    assert_eq!(attestation.expires_at, Some(expiry));
 }
 
 #[test]
-fn test_upsert_profile_rejects_negative_earnings() {
-    let env = Env::default();
-    let admin = Address::generate(&env);
+fn test_revoke_attestation() {
+    let (env, _admin, client) = setup_test_env();
+    let issuer = Address::generate(&env);
     let subject = Address::generate(&env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
-
-    let result = client.try_upsert_profile(
+    let attestation_id = client.issue_attestation(
+        &issuer,
         &subject,
-        &5_u32,
-        &1_u32,
-        &50_u32,
-        &50_u32,
-        &(-1_i128),
+        &String::from_str(&env, "contributor"),
+        &String::from_str(&env, "Active contributor"),
+        &None,
+        &None,
+    );
+
+    client.revoke_attestation(&attestation_id);
+
+    let attestation = client.get_attestation(&attestation_id);
+    assert!(attestation.revoked);
+}
+
+#[test]
+fn test_empty_label_fails() {
+    let (env, _admin, client) = setup_test_env();
+    let issuer = Address::generate(&env);
+    let subject = Address::generate(&env);
+
+    let result = client.try_issue_attestation(
+        &issuer,
+        &subject,
+        &String::from_str(&env, "contributor"),
+        &String::from_str(&env, ""),
+        &None,
+        &None,
     );
 
     assert!(result.is_err());
 }
 
 #[test]
-fn test_upsert_profile_rejects_score_over_100() {
-    let env = Env::default();
-    let admin = Address::generate(&env);
+fn test_invalid_expiry_time_fails() {
+    let (env, _admin, client) = setup_test_env();
+    let issuer = Address::generate(&env);
     let subject = Address::generate(&env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
+    let now = env.ledger().timestamp();
+    let past_expiry = now;
 
-    // Reviewer score > 100
-    let result = client.try_upsert_profile(
+    let result = client.try_issue_attestation(
+        &issuer,
         &subject,
-        &5_u32,
-        &1_u32,
-        &101_u32,
-        &50_u32,
-        &1000_i128,
-    );
-    assert!(result.is_err());
-
-    // Founder score > 100
-    let result = client.try_upsert_profile(
-        &subject,
-        &5_u32,
-        &1_u32,
-        &50_u32,
-        &101_u32,
-        &1000_i128,
-    );
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_upsert_profile_requires_admin_auth() {
-    let env = Env::default();
-    let admin = Address::generate(&env);
-    let subject = Address::generate(&env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
-
-    client.initialize(&admin);
-
-    // Call without admin auth — should fail
-    let result = client.try_upsert_profile(
-        &subject,
-        &5_u32,
-        &1_u32,
-        &50_u32,
-        &50_u32,
-        &1000_i128,
+        &String::from_str(&env, "contributor"),
+        &String::from_str(&env, "Active contributor"),
+        &None,
+        &Some(past_expiry),
     );
 
     assert!(result.is_err());
@@ -185,62 +152,117 @@ fn test_upsert_profile_requires_admin_auth() {
 
 #[test]
 fn test_get_profile_not_found() {
-    let env = Env::default();
-    let admin = Address::generate(&env);
+    let (env, _admin, client) = setup_test_env();
+
     let subject = Address::generate(&env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
-
-    client.initialize(&admin);
-
     let result = client.try_get_profile(&subject);
+    assert_eq!(result, Err(Ok(QuidError::ProfileNotFound)));
+}
+
+#[test]
+fn test_store_and_get_profile() {
+    let (env, _admin, client) = setup_test_env();
+    let subject = Address::generate(&env);
+
+    client.increment_success(&subject, &0);
+
+    let fetched = client.get_profile(&subject);
+    assert_eq!(fetched.score, 0);
+    assert_eq!(fetched.successful_missions, 1);
+    assert_eq!(fetched.missions_created, 0);
+    assert_eq!(fetched.total_earnings, 0);
+}
+
+#[test]
+fn test_load_or_default_returns_zeroed_profile() {
+    let (env, _admin, client) = setup_test_env();
+
+    let subject = Address::generate(&env);
+    let result = client.try_get_profile(&subject);
+    assert_eq!(result, Err(Ok(QuidError::ProfileNotFound)));
+}
+
+#[test]
+fn test_increment_success() {
+    let (env, _admin, client) = setup_test_env();
+    let subject = Address::generate(&env);
+
+    client.increment_success(&subject, &100);
+
+    let fetched = client.get_profile(&subject);
+    assert_eq!(fetched.successful_missions, 1);
+    assert_eq!(fetched.total_earnings, 100);
+
+    client.increment_success(&subject, &50);
+
+    let fetched2 = client.get_profile(&subject);
+    assert_eq!(fetched2.successful_missions, 2);
+    assert_eq!(fetched2.total_earnings, 150);
+}
+
+#[test]
+fn test_increment_success_invalid_reward() {
+    let (env, _admin, client) = setup_test_env();
+    let subject = Address::generate(&env);
+
+    let res = client.try_increment_success(&subject, &-10);
+    assert_eq!(res, Err(Ok(QuidError::InvalidRewardAmount)));
+}
+
+#[test]
+fn test_upsert_profile_success() {
+    let (env, _admin, client) = setup_test_env();
+    let subject = Address::generate(&env);
+
+    client.upsert_profile(&subject, &10, &2, &85, &90, &5000);
+
+    let profile = client.get_profile(&subject);
+    assert_eq!(profile.successful_missions, 10);
+    assert_eq!(profile.total_earnings, 5000);
+    assert!(profile.updated_at > 0);
+}
+
+#[test]
+fn test_upsert_profile_updates_existing() {
+    let (env, _admin, client) = setup_test_env();
+    let subject = Address::generate(&env);
+
+    client.upsert_profile(&subject, &5, &1, &70, &80, &1000);
+    client.upsert_profile(&subject, &15, &0, &95, &100, &7500);
+
+    let profile = client.get_profile(&subject);
+    assert_eq!(profile.successful_missions, 15);
+    assert_eq!(profile.total_earnings, 7500);
+}
+
+#[test]
+fn test_upsert_profile_rejects_negative_earnings() {
+    let (env, _admin, client) = setup_test_env();
+    let subject = Address::generate(&env);
+
+    let result = client.try_upsert_profile(&subject, &5, &1, &50, &50, &(-1));
     assert!(result.is_err());
 }
 
 #[test]
 fn test_upsert_profile_emits_event() {
-    let env = Env::default();
-    let admin = Address::generate(&env);
+    let (env, _admin, client) = setup_test_env();
     let subject = Address::generate(&env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
+    client.upsert_profile(&subject, &10, &2, &85, &90, &5000);
 
-    client.upsert_profile(
-        &subject,
-        &10_u32,
-        &2_u32,
-        &85_u32,
-        &90_u32,
-        &5000_i128,
-    );
-
-    // Verify event was published
     let events = env.events().all();
-    assert!(!events.is_empty(), "ProfileUpdatedEvent should have been published");
+    assert!(!events.is_empty());
 }
 
 #[test]
 fn test_upsert_profile_zero_values_allowed() {
-    let env = Env::default();
-    let admin = Address::generate(&env);
+    let (env, _admin, client) = setup_test_env();
     let subject = Address::generate(&env);
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
+    client.upsert_profile(&subject, &0, &0, &0, &0, &0);
 
-    client.upsert_profile(
-        &subject,
-        &0_u32,
-        &0_u32,
-        &0_u32,
-        &0_u32,
-        &0_i128,
-    );
-
-    let profile = client.get_profile(&subject).unwrap();
+    let profile = client.get_profile(&subject);
     assert_eq!(profile.total_earnings, 0);
     assert_eq!(profile.successful_missions, 0);
 }

--- a/quid-contract/contracts/quid-reputation/src/test.rs
+++ b/quid-contract/contracts/quid-reputation/src/test.rs
@@ -1,0 +1,246 @@
+﻿#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Env as _},
+    Address, Env,
+};
+
+use crate::{QuidReputationContract, QuidReputationContractClient, Profile};
+
+fn setup_contract<'a>(env: &Env) -> QuidReputationContractClient<'a> {
+    let admin = Address::generate(env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(env, &contract_id);
+    client.initialize(&admin);
+    client
+}
+
+#[test]
+fn test_initialize_sets_admin() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+#[should_panic(expected = "Already initialized")]
+fn test_double_initialize_fails() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.initialize(&admin);
+}
+
+#[test]
+fn test_upsert_profile_success() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    client.upsert_profile(
+        &subject,
+        &10_u32,
+        &2_u32,
+        &85_u32,
+        &90_u32,
+        &5000_i128,
+    );
+
+    let profile = client.get_profile(&subject).unwrap();
+    assert_eq!(profile.subject, subject);
+    assert_eq!(profile.successful_missions, 10);
+    assert_eq!(profile.rejected_submissions, 2);
+    assert_eq!(profile.reviewer_score, 85);
+    assert_eq!(profile.founder_score, 90);
+    assert_eq!(profile.total_earnings, 5000);
+    assert!(profile.updated_at > 0);
+}
+
+#[test]
+fn test_upsert_profile_updates_existing() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    // First upsert
+    client.upsert_profile(
+        &subject,
+        &5_u32,
+        &1_u32,
+        &70_u32,
+        &80_u32,
+        &1000_i128,
+    );
+
+    // Second upsert — overwrites
+    client.upsert_profile(
+        &subject,
+        &15_u32,
+        &0_u32,
+        &95_u32,
+        &100_u32,
+        &7500_i128,
+    );
+
+    let profile = client.get_profile(&subject).unwrap();
+    assert_eq!(profile.successful_missions, 15);
+    assert_eq!(profile.rejected_submissions, 0);
+    assert_eq!(profile.reviewer_score, 95);
+    assert_eq!(profile.founder_score, 100);
+    assert_eq!(profile.total_earnings, 7500);
+}
+
+#[test]
+fn test_upsert_profile_rejects_negative_earnings() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let result = client.try_upsert_profile(
+        &subject,
+        &5_u32,
+        &1_u32,
+        &50_u32,
+        &50_u32,
+        &(-1_i128),
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_upsert_profile_rejects_score_over_100() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    // Reviewer score > 100
+    let result = client.try_upsert_profile(
+        &subject,
+        &5_u32,
+        &1_u32,
+        &101_u32,
+        &50_u32,
+        &1000_i128,
+    );
+    assert!(result.is_err());
+
+    // Founder score > 100
+    let result = client.try_upsert_profile(
+        &subject,
+        &5_u32,
+        &1_u32,
+        &50_u32,
+        &101_u32,
+        &1000_i128,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_upsert_profile_requires_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    // Call without admin auth — should fail
+    let result = client.try_upsert_profile(
+        &subject,
+        &5_u32,
+        &1_u32,
+        &50_u32,
+        &50_u32,
+        &1000_i128,
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_get_profile_not_found() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let result = client.try_get_profile(&subject);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_upsert_profile_emits_event() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    client.upsert_profile(
+        &subject,
+        &10_u32,
+        &2_u32,
+        &85_u32,
+        &90_u32,
+        &5000_i128,
+    );
+
+    // Verify event was published
+    let events = env.events().all();
+    assert!(!events.is_empty(), "ProfileUpdatedEvent should have been published");
+}
+
+#[test]
+fn test_upsert_profile_zero_values_allowed() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let subject = Address::generate(&env);
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    client.upsert_profile(
+        &subject,
+        &0_u32,
+        &0_u32,
+        &0_u32,
+        &0_u32,
+        &0_i128,
+    );
+
+    let profile = client.get_profile(&subject).unwrap();
+    assert_eq!(profile.total_earnings, 0);
+    assert_eq!(profile.successful_missions, 0);
+}

--- a/quid-contract/contracts/quid-store/Cargo.toml
+++ b/quid-contract/contracts/quid-store/Cargo.toml
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 [package]
 name = "quid-store"
 version = "0.0.0"
@@ -13,3 +14,20 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+=======
+[package]
+name = "quid-store"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)

--- a/quid-contract/contracts/quid-store/Makefile
+++ b/quid-contract/contracts/quid-store/Makefile
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 default: build
 
 all: test
@@ -14,3 +15,21 @@ fmt:
 
 clean:
 	cargo clean
+=======
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean
+>>>>>>> f0c6f47 (feat(contracts): implement upsert profile)


### PR DESCRIPTION
Closes #193

Implements the admin-only upsert_profile entrypoint for the Quid reputation contract.

- upsert_profile (admin-only, rejects negative earnings, stores with updated_at, emits event)
- bootstrap_admin / get_admin
- get_profile / increment_success
- issue_attestation / get_attestation / revoke_attestation

Replaces #210 which was accidentally closed.