### PR TITLE
chore(ci): add frontend type-check to pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Linting
         run: npm run lint
 
+      - name: Type check
+        run: npm run type-check
+
       - name: Build Frontend
         run: npm run build
 

--- a/frontend/src/types/static-images.d.ts
+++ b/frontend/src/types/static-images.d.ts
@@ -1,0 +1,12 @@
+declare module "*.png" {
+  const src: {
+    src: string;
+    height: number;
+    width: number;
+    blurDataURL?: string;
+    blurWidth?: number;
+    blurHeight?: number;
+  };
+  export default src;
+}
+


### PR DESCRIPTION
## Summary
- add `npm run type-check` to the frontend CI job after linting
- add a tracked PNG module declaration so clean CI can type-check existing static image imports

Closes #245.

## Validation
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `npm run build`

Validation was run in a clean `/tmp/quid-245-verify` clone because the local workspace under `/Users/rated-r/rated r brain` makes Next/Turbopack infer the wrong parent workspace root from the brain-level `package-lock.json`.