### PR TITLE
Admin bootstrap and admin getter

### DIFF
--- a/quid-contract/contracts/quid-reputation/src/error.rs
+++ b/quid-contract/contracts/quid-reputation/src/error.rs
@@ -9,6 +9,4 @@ pub enum ReputationError {
     InvalidInput = 4,
     /// No profile exists for the given subject address.
     ProfileNotFound = 5,
-    /// No admin has been bootstrapped yet.
-    AdminNotSet = 6,
 }

--- a/quid-contract/contracts/quid-reputation/src/error.rs
+++ b/quid-contract/contracts/quid-reputation/src/error.rs
@@ -9,4 +9,6 @@ pub enum ReputationError {
     InvalidInput = 4,
     /// No profile exists for the given subject address.
     ProfileNotFound = 5,
+    /// No admin has been bootstrapped yet.
+    AdminNotSet = 6,
 }

--- a/quid-contract/contracts/quid-reputation/src/lib.rs
+++ b/quid-contract/contracts/quid-reputation/src/lib.rs
@@ -20,12 +20,24 @@ impl QuidReputationContract {
     // Admin bootstrap
     // -------------------------------------------------------------------------
 
-    /// Initialize the contract with an admin address. May only be called once.
-    pub fn initialize(env: Env, admin: Address) -> Result<(), ReputationError> {
-        admin.require_auth();
-
-        if env.storage().instance().has(&DataKey::Admin) {
-            return Err(ReputationError::InvalidInput);
+    /// Bootstrap or rotate the admin.
+    ///
+    /// - First call (no admin set): `admin` self-authorizes.
+    /// - Subsequent calls: the current admin must authorize the change.
+    pub fn set_admin(env: Env, admin: Address) -> Result<(), ReputationError> {
+        match env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::Admin)
+        {
+            // No admin yet — new admin self-authorizes.
+            None => {
+                admin.require_auth();
+            }
+            // Admin already set — current admin must authorize the rotation.
+            Some(current_admin) => {
+                current_admin.require_auth();
+            }
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -33,11 +45,13 @@ impl QuidReputationContract {
     }
 
     /// Get the admin address.
+    ///
+    /// Returns `AdminNotSet` when no admin has been bootstrapped yet.
     pub fn get_admin(env: Env) -> Result<Address, ReputationError> {
         env.storage()
             .instance()
             .get(&DataKey::Admin)
-            .ok_or(ReputationError::NotAuthorized)
+            .ok_or(ReputationError::AdminNotSet)
     }
 
     // -------------------------------------------------------------------------
@@ -174,14 +188,14 @@ impl QuidReputationContract {
 #[allow(dead_code)]
 impl QuidReputationContract {
     /// Require that `caller` is the bootstrapped admin.
-    /// Returns `NotAuthorized` if no admin has been bootstrapped yet or the
-    /// caller does not match.
+    /// Returns `AdminNotSet` if no admin has been bootstrapped yet, or
+    /// `NotAuthorized` if the caller does not match.
     pub(crate) fn require_admin(env: &Env, caller: &Address) -> Result<(), ReputationError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .ok_or(ReputationError::NotAuthorized)?;
+            .ok_or(ReputationError::AdminNotSet)?;
 
         admin.require_auth();
 

--- a/quid-contract/contracts/quid-reputation/src/lib.rs
+++ b/quid-contract/contracts/quid-reputation/src/lib.rs
@@ -20,24 +20,12 @@ impl QuidReputationContract {
     // Admin bootstrap
     // -------------------------------------------------------------------------
 
-    /// Bootstrap or rotate the admin.
-    ///
-    /// - First call (no admin set): `admin` self-authorizes.
-    /// - Subsequent calls: the current admin must authorize the change.
-    pub fn set_admin(env: Env, admin: Address) -> Result<(), ReputationError> {
-        match env
-            .storage()
-            .instance()
-            .get::<DataKey, Address>(&DataKey::Admin)
-        {
-            // No admin yet — new admin self-authorizes.
-            None => {
-                admin.require_auth();
-            }
-            // Admin already set — current admin must authorize the rotation.
-            Some(current_admin) => {
-                current_admin.require_auth();
-            }
+    /// Initialize the contract with an admin address. May only be called once.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ReputationError> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(ReputationError::InvalidInput);
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -45,13 +33,11 @@ impl QuidReputationContract {
     }
 
     /// Get the admin address.
-    ///
-    /// Returns `AdminNotSet` when no admin has been bootstrapped yet.
     pub fn get_admin(env: Env) -> Result<Address, ReputationError> {
         env.storage()
             .instance()
             .get(&DataKey::Admin)
-            .ok_or(ReputationError::AdminNotSet)
+            .ok_or(ReputationError::NotAuthorized)
     }
 
     // -------------------------------------------------------------------------
@@ -188,14 +174,14 @@ impl QuidReputationContract {
 #[allow(dead_code)]
 impl QuidReputationContract {
     /// Require that `caller` is the bootstrapped admin.
-    /// Returns `AdminNotSet` if no admin has been bootstrapped yet, or
-    /// `NotAuthorized` if the caller does not match.
+    /// Returns `NotAuthorized` if no admin has been bootstrapped yet or the
+    /// caller does not match.
     pub(crate) fn require_admin(env: &Env, caller: &Address) -> Result<(), ReputationError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .ok_or(ReputationError::AdminNotSet)?;
+            .ok_or(ReputationError::NotAuthorized)?;
 
         admin.require_auth();
 

--- a/quid-contract/contracts/quid-reputation/src/test.rs
+++ b/quid-contract/contracts/quid-reputation/src/test.rs
@@ -14,7 +14,7 @@ fn setup_test_env() -> (Env, Address, Address) {
     let admin = Address::generate(&env);
 
     let client = QuidReputationContractClient::new(&env, &contract_id);
-    client.set_admin(&admin);
+    client.initialize(&admin);
 
     (env, contract_id, admin)
 }
@@ -24,7 +24,7 @@ fn setup_test_env() -> (Env, Address, Address) {
 // -------------------------------------------------------------------------
 
 #[test]
-fn test_set_admin_bootstrap() {
+fn test_initialize() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -33,38 +33,10 @@ fn test_set_admin_bootstrap() {
 
     let admin = Address::generate(&env);
 
-    // First call: new admin self-authorizes.
-    client.set_admin(&admin);
+    client.initialize(&admin);
 
     let stored_admin = client.get_admin();
     assert_eq!(stored_admin, admin);
-}
-
-#[test]
-fn test_set_admin_rotation() {
-    let (env, contract_id, admin) = setup_test_env();
-    let client = QuidReputationContractClient::new(&env, &contract_id);
-
-    let new_admin = Address::generate(&env);
-
-    // Rotation: current admin authorizes the change.
-    client.set_admin(&new_admin);
-
-    assert_eq!(client.get_admin(), new_admin);
-    // Old admin should no longer be stored.
-    assert_ne!(client.get_admin(), admin);
-}
-
-#[test]
-fn test_get_admin_not_set() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(QuidReputationContract, ());
-    let client = QuidReputationContractClient::new(&env, &contract_id);
-
-    let result = client.try_get_admin();
-    assert_eq!(result, Err(Ok(ReputationError::AdminNotSet)));
 }
 
 // -------------------------------------------------------------------------

--- a/quid-contract/contracts/quid-reputation/src/test.rs
+++ b/quid-contract/contracts/quid-reputation/src/test.rs
@@ -14,7 +14,7 @@ fn setup_test_env() -> (Env, Address, Address) {
     let admin = Address::generate(&env);
 
     let client = QuidReputationContractClient::new(&env, &contract_id);
-    client.initialize(&admin);
+    client.set_admin(&admin);
 
     (env, contract_id, admin)
 }
@@ -24,7 +24,7 @@ fn setup_test_env() -> (Env, Address, Address) {
 // -------------------------------------------------------------------------
 
 #[test]
-fn test_initialize() {
+fn test_set_admin_bootstrap() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -33,10 +33,38 @@ fn test_initialize() {
 
     let admin = Address::generate(&env);
 
-    client.initialize(&admin);
+    // First call: new admin self-authorizes.
+    client.set_admin(&admin);
 
     let stored_admin = client.get_admin();
     assert_eq!(stored_admin, admin);
+}
+
+#[test]
+fn test_set_admin_rotation() {
+    let (env, contract_id, admin) = setup_test_env();
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+
+    // Rotation: current admin authorizes the change.
+    client.set_admin(&new_admin);
+
+    assert_eq!(client.get_admin(), new_admin);
+    // Old admin should no longer be stored.
+    assert_ne!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_get_admin_not_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuidReputationContract, ());
+    let client = QuidReputationContractClient::new(&env, &contract_id);
+
+    let result = client.try_get_admin();
+    assert_eq!(result, Err(Ok(ReputationError::AdminNotSet)));
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
close #191 

Overview
This PR implements the administration management lifecycle for the reputation contract. It introduces methods to securely bootstrap an initial admin via self-authorization and safely rotate administration privileges using existing admin authorization.

## 📋 Proposed Changes
* **Admin Mutation:** Added `set_admin(env: Env, admin: Address)` to handle initial bootstrapping and subsequent admin updates.
* **Admin Query:** Added `get_admin(env: Env) -> Result<Address, Error>` to read the active contract administrator.
* **Auth Enforcement:** Implemented a dual-state authorization check: self-authorization for the first-time set, and existing admin authorization for updates.
* **Error Handling:** Integrated the `AdminNotSet` error condition when querying an uninitialized admin status.

## ✅ Requirements & Acceptance Criteria
- [x] Implemented `set_admin(env, admin)` and `get_admin(env)`.
- [x] Initial bootstrap requires self-authorization from the new admin.
- [x] Admin rotation requires authorization from the currently active admin.
- [x] `get_admin` safely returns `Error::AdminNotSet` if storage is empty.

## 🗂️ Targeted File Changes
* `quid-contract/contracts/quid-reputation/src/lib.rs`

---

## 🛠️ Implementation Blueprint

Below is the clean Rust reference logic matching your requirements for `src/lib.rs`:

```rust
use soroban_sdk::{contractimpl, contracttype, Address, Env};
// Ensure your existing Error enum includes AdminNotSet

#[contracttype]
pub enum DataKey {
    Admin,
}

pub struct QuidReputationContract;

#[contractimpl]
impl QuidReputationContract {
    pub fn set_admin(env: Env, admin: Address) -> Result<(), Error> {
        let current_admin: Option<Address> = env.storage().instance().get(&DataKey::Admin);

        match current_admin {
            Some(existing_admin) => {
                // Admin is already set; current admin must authorize the rotation
                existing_admin.require_auth();
            }
            None => {
                // Admin is not set; new admin must self-authorize to bootstrap
                admin.require_auth();
            }
        }

        env.storage().instance().set(&DataKey::Admin, &admin);
        Ok(())
    }

    pub fn get_admin(env: Env) -> Result<Address, Error> {
        env.storage()
            .instance()
            .get(&DataKey::Admin)
            .ok_or(Error::AdminNotSet)
    }
}
```

---

## 🧪 Verification Plan
* Run local Soroban unit tests to confirm initial bootstrap passing with new admin auth.
* Assert that unauthorized addresses trying to overwrite `set_admin` throw a contract panic.
* Verify `get_admin` yields `AdminNotSet` on a clean, uninitialized environment instance.
