### PR TITLE
feat(backend): get latest mission draft for creator

### DIFF
--- a/backend/src/missions/missions.controller.spec.ts
+++ b/backend/src/missions/missions.controller.spec.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
 import { MissionsController } from './missions.controller';
 import { MissionsService } from './missions.service';
 import {
@@ -6,6 +7,7 @@ import {
   MissionListSort,
 } from './dto/list-missions-query.dto';
 import { SaveDraftDto } from './dto/save-draft.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 describe('MissionsController', () => {
   let controller: MissionsController;
@@ -17,6 +19,7 @@ describe('MissionsController', () => {
     approveSubmission: jest.Mock;
     rejectSubmission: jest.Mock;
     saveDraft: jest.Mock;
+    getLatestDraft: jest.Mock;
   };
 
   beforeEach(() => {
@@ -28,6 +31,7 @@ describe('MissionsController', () => {
       approveSubmission: jest.fn(),
       rejectSubmission: jest.fn(),
       saveDraft: jest.fn(),
+      getLatestDraft: jest.fn(),
     };
 
     controller = new MissionsController(
@@ -144,5 +148,31 @@ describe('MissionsController', () => {
 
     expect(result).toEqual(mockDraft);
     expect(missionsService.saveDraft).toHaveBeenCalledWith('0xabc', dto);
+  });
+
+  it('returns the latest draft for the authenticated user', async () => {
+    const mockDraft = {
+      id: 'draft-1',
+      ownerAddress: '0xabc',
+      title: 'My Draft',
+      data: { field: 'value' },
+    };
+    missionsService.getLatestDraft.mockResolvedValue(mockDraft);
+
+    await expect(
+      controller.getLatestDraft({
+        user: { userId: 'user-1', address: '0xabc' },
+      } as any),
+    ).resolves.toEqual(mockDraft);
+    expect(missionsService.getLatestDraft).toHaveBeenCalledWith('0xabc');
+  });
+
+  it('requires JWT authentication to get the latest draft', () => {
+    // Reading decorator metadata requires the original prototype method.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const getLatestDraft = MissionsController.prototype.getLatestDraft;
+    const guards = Reflect.getMetadata(GUARDS_METADATA, getLatestDraft);
+
+    expect(guards).toContain(JwtAuthGuard);
   });
 });

--- a/backend/src/missions/missions.controller.ts
+++ b/backend/src/missions/missions.controller.ts
@@ -39,6 +39,14 @@ export class MissionsController {
     return this.missionsService.getMyMissions(req.user.address);
   }
 
+  @UseGuards(JwtAuthGuard)
+  @Get('drafts/me')
+  getLatestDraft(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<Prisma.MissionDraftGetPayload<null>> {
+    return this.missionsService.getLatestDraft(req.user.address);
+  }
+
   @Get(':id')
   detail(@Param('id') id: string): Promise<unknown> {
     return this.missionsService.getMission(id);

--- a/backend/src/missions/missions.service.spec.ts
+++ b/backend/src/missions/missions.service.spec.ts
@@ -458,4 +458,32 @@ describe('MissionsService', () => {
       expect(result).toEqual(updatedDraft);
     });
   });
+
+  describe('getLatestDraft', () => {
+    it('returns the most recently updated draft for the owner', async () => {
+      const latestDraft = {
+        id: 'draft-2',
+        ownerAddress: '0xabc',
+        title: 'Latest Draft',
+        data: { step: 3 },
+      };
+      prisma.missionDraft.findFirst.mockResolvedValue(latestDraft);
+
+      await expect(service.getLatestDraft('0xabc')).resolves.toEqual(
+        latestDraft,
+      );
+      expect(prisma.missionDraft.findFirst).toHaveBeenCalledWith({
+        where: { ownerAddress: '0xabc' },
+        orderBy: { updatedAt: 'desc' },
+      });
+    });
+
+    it('throws NotFoundException when the owner has no draft', async () => {
+      prisma.missionDraft.findFirst.mockResolvedValue(null);
+
+      await expect(service.getLatestDraft('0xabc')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
 });

--- a/backend/src/missions/missions.service.ts
+++ b/backend/src/missions/missions.service.ts
@@ -53,8 +53,7 @@ export class MissionsService {
 
   async listPublicMissions(query: ListMissionsQueryDto): Promise<unknown> {
     const normalizedStatus = query.status?.toUpperCase() as
-      | MissionStatus
-      | undefined;
+      MissionStatus | undefined;
     const where = normalizedStatus ? { status: normalizedStatus } : {};
     const orderBy = {
       createdAt: query.sort === MissionListSort.OLDEST ? 'asc' : 'desc',
@@ -121,6 +120,21 @@ export class MissionsService {
       },
     });
     return created;
+  }
+
+  async getLatestDraft(
+    ownerAddress: string,
+  ): Promise<Prisma.MissionDraftGetPayload<null>> {
+    const draft = await this.prisma.missionDraft.findFirst({
+      where: { ownerAddress },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    if (!draft) {
+      throw new NotFoundException('Mission draft not found');
+    }
+
+    return draft;
   }
 
   async getMissionSubmissions(


### PR DESCRIPTION
## Summary

Adds an authenticated endpoint for creators to retrieve their latest saved mission draft and resume the mission wizard.

## Changes

- Add `GET /missions/drafts/me`
- Require JWT authentication
- Retrieve the caller's most recently updated draft
- Return `404` when no draft exists
- Add controller and service tests

## Testing

- 38 backend tests passing
- ESLint passing
- Prettier passing
- Backend build passing

Closes #269