### PR TITLE
feat(frontend): wire creator quests list to API

### DIFF
--- a/frontend/src/components/creator/quests/QuestRow.tsx
+++ b/frontend/src/components/creator/quests/QuestRow.tsx
@@ -49,59 +49,66 @@ export default function QuestRow({ quest }: { quest: QuestRowData }) {
 
   return (
     <div className="flex items-start gap-4 py-4 sm:items-center">
-      <Image
-        src="/namelogo.png"
-        alt=""
-        width={56}
-        height={56}
-        className="size-12 shrink-0 rounded-lg object-cover sm:size-14"
-      />
+      <Link
+        href={`/creator/quests/${quest.id}`}
+        className="flex min-w-0 flex-1 items-start gap-4 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8B5CF6] sm:items-center"
+      >
+        <Image
+          src="/namelogo.png"
+          alt=""
+          width={56}
+          height={56}
+          className="size-12 shrink-0 rounded-lg object-cover sm:size-14"
+        />
 
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <h3 className="truncate text-base font-semibold text-white">
-            {quest.title}
-          </h3>
-          <span
-            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${TAG_STYLES[quest.tagVariant]}`}
-          >
-            <span className="size-1.5 rounded-full bg-current" />
-            {quest.tagLabel}
-          </span>
-        </div>
-        <p className="mt-0.5 text-sm text-white/40">
-          {quest.category} • {quest.tagLabel}
-        </p>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="truncate text-base font-semibold text-white">
+              {quest.title}
+            </h3>
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${TAG_STYLES[quest.tagVariant]}`}
+            >
+              <span className="size-1.5 rounded-full bg-current" />
+              {quest.tagLabel}
+            </span>
+          </div>
+          <p className="mt-0.5 text-sm text-white/40">
+            {quest.category} • {quest.tagLabel}
+          </p>
 
-        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-white/50">
-          <span className="flex items-center gap-1.5">
-            <Image
-              src={stellarIcon}
-              alt=""
-              width={14}
-              height={14}
-              className="h-3.5 w-3.5"
-            />
-            <span className="font-medium text-white/80">{quest.pool} XLM</span>{" "}
-            Pool
-          </span>
-          <span className="flex items-center gap-1.5">
-            <Image
-              src={stellarIcon}
-              alt=""
-              width={14}
-              height={14}
-              className="h-3.5 w-3.5"
-            />
-            <span className="font-medium text-white/80">
-              {quest.perWinner} XLM
-            </span>{" "}
-            Per winner
-          </span>
-          <span>{quest.responses} responses</span>
-          <span>{quest.meta}</span>
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-white/50">
+            <span className="flex items-center gap-1.5">
+              <Image
+                src={stellarIcon}
+                alt=""
+                width={14}
+                height={14}
+                className="h-3.5 w-3.5"
+              />
+              <span className="font-medium text-white/80">
+                {quest.pool} XLM
+              </span>{" "}
+              Pool
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Image
+                src={stellarIcon}
+                alt=""
+                width={14}
+                height={14}
+                className="h-3.5 w-3.5"
+              />
+              <span className="font-medium text-white/80">
+                {quest.perWinner} XLM
+              </span>{" "}
+              Per winner
+            </span>
+            <span>{quest.responses} responses</span>
+            <span>{quest.meta}</span>
+          </div>
         </div>
-      </div>
+      </Link>
 
       <div className="flex shrink-0 items-center gap-2">
         <Link

--- a/frontend/src/components/creator/quests/QuestsHub.tsx
+++ b/frontend/src/components/creator/quests/QuestsHub.tsx
@@ -1,62 +1,26 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { AlertCircle, LoaderCircle } from "lucide-react";
 import QuestRow from "./QuestRow";
 import EmptyActiveQuests from "./EmptyActiveQuests";
 import type { QuestRowData, QuestTabKey } from "./types";
+import { useWallet } from "@/context/WalletProvider";
+import { creatorApiFetch } from "@/lib/creator-api";
 
-// Fixture data until GET /missions/me is wired up.
-const QUESTS: QuestRowData[] = [
-  {
-    id: "1",
-    title: "Download and test the latest Ruze.stellar 2.0",
-    tagLabel: "Reviewing submissions",
-    tagVariant: "active",
-    category: "Product testing",
-    pool: 610,
-    perWinner: 10,
-    responses: 72,
-    meta: "Expired 2d ago",
-    tab: "active",
-  },
-  {
-    id: "2",
-    title: "Untitled quest",
-    tagLabel: "Draft",
-    tagVariant: "draft",
-    category: "Product testing",
-    pool: 1250,
-    perWinner: 52,
-    responses: 0,
-    meta: "Last edited 8m ago",
-    tab: "drafted",
-  },
-  {
-    id: "3",
-    title: "Creator onboarding research",
-    tagLabel: "Draft",
-    tagVariant: "draft",
-    category: "Community participation",
-    pool: 0,
-    perWinner: 0,
-    responses: 0,
-    meta: "Last edited 2d ago",
-    tab: "drafted",
-  },
-  {
-    id: "4",
-    title: "Wallet transfer flow feedback",
-    tagLabel: "Completed",
-    tagVariant: "completed",
-    category: "Product testing",
-    pool: 1250,
-    perWinner: 52,
-    responses: 40,
-    meta: "Completed Jun 6",
-    tab: "completed",
-  },
-];
+type MissionStatus = "OPEN" | "STARTED" | "PAUSED" | "COMPLETED" | "CANCELLED";
+
+interface MissionResponse {
+  id: string;
+  title: string;
+  status: MissionStatus;
+  metadata: unknown;
+  rewardAmount: string;
+  maxParticipants: number;
+  updatedAt: string;
+  _count?: { submissions?: number };
+}
 
 const TABS: { key: QuestTabKey; label: string }[] = [
   { key: "active", label: "Active Quest" },
@@ -64,16 +28,125 @@ const TABS: { key: QuestTabKey; label: string }[] = [
   { key: "completed", label: "Completed" },
 ];
 
-export default function QuestsHub() {
-  const [activeTab, setActiveTab] = useState<QuestTabKey>("active");
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
 
-  const counts: Record<QuestTabKey, number> = {
-    active: QUESTS.filter((quest) => quest.tab === "active").length,
-    drafted: QUESTS.filter((quest) => quest.tab === "drafted").length,
-    completed: QUESTS.filter((quest) => quest.tab === "completed").length,
+function asNumber(value: unknown): number | null {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getRelativeTime(value: string): string {
+  const elapsedSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - new Date(value).getTime()) / 1000),
+  );
+
+  if (elapsedSeconds < 60) return "just now";
+  if (elapsedSeconds < 3600) return `${Math.floor(elapsedSeconds / 60)}m ago`;
+  if (elapsedSeconds < 86400) {
+    return `${Math.floor(elapsedSeconds / 3600)}h ago`;
+  }
+  return `${Math.floor(elapsedSeconds / 86400)}d ago`;
+}
+
+function missionTab(status: MissionStatus): QuestTabKey {
+  if (status === "PAUSED") return "drafted";
+  if (status === "COMPLETED" || status === "CANCELLED") return "completed";
+  return "active";
+}
+
+function mapMissionToQuest(mission: MissionResponse): QuestRowData {
+  const tab = missionTab(mission.status);
+  const metadata = asRecord(mission.metadata);
+  const perWinner = asNumber(mission.rewardAmount) ?? 0;
+  const configuredPool = asNumber(metadata.pool);
+
+  return {
+    id: mission.id,
+    title: mission.title,
+    tagLabel:
+      mission.status === "CANCELLED"
+        ? "Cancelled"
+        : tab === "drafted"
+          ? "Draft"
+          : tab === "completed"
+            ? "Completed"
+            : mission.status === "STARTED"
+              ? "Reviewing submissions"
+              : "Active",
+    tagVariant:
+      tab === "drafted" ? "draft" : tab === "completed" ? "completed" : "active",
+    category:
+      typeof metadata.category === "string" ? metadata.category : "General",
+    pool: configuredPool ?? perWinner * mission.maxParticipants,
+    perWinner,
+    responses: mission._count?.submissions ?? 0,
+    meta:
+      tab === "completed"
+        ? `${mission.status === "CANCELLED" ? "Cancelled" : "Completed"} ${new Date(
+            mission.updatedAt,
+          ).toLocaleDateString(undefined, {
+            month: "short",
+            day: "numeric",
+          })}`
+        : `${tab === "drafted" ? "Last edited" : "Updated"} ${getRelativeTime(
+            mission.updatedAt,
+          )}`,
+    tab,
   };
+}
 
-  const visibleQuests = QUESTS.filter((quest) => quest.tab === activeTab);
+export default function QuestsHub() {
+  const { connected, publicKey, connect } = useWallet();
+  const [activeTab, setActiveTab] = useState<QuestTabKey>("active");
+  const [quests, setQuests] = useState<QuestRowData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadQuests = useCallback(async () => {
+    if (!publicKey) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await creatorApiFetch("/missions/me", publicKey);
+      if (!response.ok) {
+        throw new Error(`Unable to load quests (${response.status})`);
+      }
+
+      const missions = (await response.json()) as MissionResponse[];
+      setQuests(missions.map(mapMissionToQuest));
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Unable to load your quests",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [publicKey]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => void loadQuests(), 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [loadQuests]);
+
+  const counts = useMemo<Record<QuestTabKey, number>>(
+    () => ({
+      active: quests.filter((quest) => quest.tab === "active").length,
+      drafted: quests.filter((quest) => quest.tab === "drafted").length,
+      completed: quests.filter((quest) => quest.tab === "completed").length,
+    }),
+    [quests],
+  );
+
+  const visibleQuests = quests.filter((quest) => quest.tab === activeTab);
 
   return (
     <div>
@@ -130,7 +203,37 @@ export default function QuestsHub() {
       </div>
 
       <div className="pt-6">
-        {visibleQuests.length === 0 ? (
+        {!connected || !publicKey ? (
+          <div className="flex flex-col items-center py-12 text-center">
+            <p className="text-sm text-white/50">
+              Connect your wallet to load your quests.
+            </p>
+            <button
+              type="button"
+              onClick={() => void connect()}
+              className="mt-4 rounded-lg bg-[#8B5CF6] px-4 py-2 text-sm font-semibold text-white hover:bg-[#7c0de0]"
+            >
+              Connect wallet
+            </button>
+          </div>
+        ) : loading ? (
+          <div className="flex items-center justify-center gap-2 py-12 text-sm text-white/50">
+            <LoaderCircle className="size-4 animate-spin" />
+            Loading quests…
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center py-12 text-center">
+            <AlertCircle className="mb-3 size-6 text-red-400" />
+            <p className="text-sm text-red-300">{error}</p>
+            <button
+              type="button"
+              onClick={() => void loadQuests()}
+              className="mt-4 rounded-md border border-white/15 px-3 py-1.5 text-sm text-white hover:bg-white/5"
+            >
+              Try again
+            </button>
+          </div>
+        ) : visibleQuests.length === 0 ? (
           activeTab === "active" ? (
             <EmptyActiveQuests />
           ) : (

--- a/frontend/src/lib/creator-api.ts
+++ b/frontend/src/lib/creator-api.ts
@@ -1,0 +1,111 @@
+import { signFreighterTransaction } from "@/lib/freighter-wallet";
+import type { Networks } from "@stellar/stellar-sdk";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
+const SESSION_KEY = "quid_creator_auth";
+
+interface CreatorSession {
+  address: string;
+  accessToken: string;
+}
+
+interface ChallengeResponse {
+  transaction: string;
+  networkPassphrase: Networks;
+}
+
+interface VerifyResponse {
+  access_token: string;
+}
+
+function getApiUrl(path: string): string {
+  if (!API_URL) {
+    throw new Error("NEXT_PUBLIC_API_URL is not configured");
+  }
+
+  return `${API_URL}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function readSession(address: string): CreatorSession | null {
+  try {
+    const stored = localStorage.getItem(SESSION_KEY);
+    if (!stored) return null;
+
+    const session = JSON.parse(stored) as Partial<CreatorSession>;
+    if (session.address !== address || !session.accessToken) {
+      localStorage.removeItem(SESSION_KEY);
+      return null;
+    }
+
+    return session as CreatorSession;
+  } catch {
+    localStorage.removeItem(SESSION_KEY);
+    return null;
+  }
+}
+
+function clearSession(): void {
+  localStorage.removeItem(SESSION_KEY);
+}
+
+async function authenticate(address: string): Promise<CreatorSession> {
+  const challengeResponse = await fetch(
+    getApiUrl(`/auth/challenge?address=${encodeURIComponent(address)}`),
+  );
+  if (!challengeResponse.ok) {
+    throw new Error("Unable to start wallet authentication");
+  }
+
+  const challenge = (await challengeResponse.json()) as ChallengeResponse;
+  const signedXdr = await signFreighterTransaction(
+    challenge.transaction,
+    address,
+    challenge.networkPassphrase,
+  );
+
+  const verifyResponse = await fetch(getApiUrl("/auth/verify"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ signedXdr }),
+  });
+  if (!verifyResponse.ok) {
+    throw new Error("Wallet authentication failed");
+  }
+
+  const verified = (await verifyResponse.json()) as VerifyResponse;
+  if (!verified.access_token) {
+    throw new Error("Authentication response did not include an access token");
+  }
+
+  const session = { address, accessToken: verified.access_token };
+  localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  return session;
+}
+
+async function getSession(address: string): Promise<CreatorSession> {
+  return readSession(address) ?? authenticate(address);
+}
+
+export async function creatorApiFetch(
+  path: string,
+  address: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const request = async (accessToken: string) => {
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${accessToken}`);
+
+    return fetch(getApiUrl(path), { ...init, headers });
+  };
+
+  let session = await getSession(address);
+  let response = await request(session.accessToken);
+
+  if (response.status === 401) {
+    clearSession();
+    session = await authenticate(address);
+    response = await request(session.accessToken);
+  }
+
+  return response;
+}

--- a/frontend/src/lib/freighter-wallet.ts
+++ b/frontend/src/lib/freighter-wallet.ts
@@ -41,9 +41,10 @@ export async function getFreighterAddressIfConnected(): Promise<string | null> {
 export async function signFreighterTransaction(
   unsignedXdr: string,
   address: string,
+  networkPassphrase: Networks = NETWORK_PASSPHRASE,
 ): Promise<string> {
   const { signedTxXdr } = await signTransaction(unsignedXdr, {
-    networkPassphrase: NETWORK_PASSPHRASE,
+    networkPassphrase,
     address,
   });
 


### PR DESCRIPTION
## Summary

Connects the creator Quests hub to the authenticated `GET /missions/me` endpoint, replacing the hardcoded quest fixtures with live mission data.

## Changes

- Load creator missions from `GET /missions/me`
- Authenticate through the SEP-10 challenge/sign/verify flow
- Store the JWT and attach it as a Bearer token
- Re-authenticate once when the API returns `401`
- Map mission statuses into Active, Drafted, and Completed tabs
- Display live tab counts and submission counts
- Add loading, wallet-connect, error/retry, and empty states
- Link quest rows to `/creator/quests/[id]`
- Remove the hardcoded quest list

## Status Mapping

- `OPEN`, `STARTED` → Active
- `PAUSED` → Drafted
- `COMPLETED`, `CANCELLED` → Completed

## Testing

- Targeted ESLint passed
- Next.js production build passed
- `git diff --check` passed

Closes #262