### PR TITLE
feat(backend): rate limit auth and CORS for creator FE

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ IPFS (feedback blobs; CID stored on-chain)
 ```bash
 cd frontend
 npm install
-cp .env.local.example .env.local   # or create .env.local (see frontend/README.md)
+cp .env.local.example .env.local   # fill NEXT_PUBLIC_API_URL and contract IDs (see frontend/README.md)
 npm run dev
 ```
 
@@ -88,7 +88,7 @@ Open [http://localhost:3000](http://localhost:3000).
 ```bash
 cd backend
 docker compose up -d
-cp .env.example .env               # fill STELLAR_SERVER_SECRET, JWT_SECRET
+cp .env.example .env               # fill STELLAR_SERVER_SECRET, JWT_SECRET, CORS_ORIGINS
 npm install
 npm run prisma:migrate
 npm run start:dev

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL="postgresql://quid:quid@localhost:5432/quid_dev?schema=public"
 PORT=3001
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"
+CORS_ORIGINS="http://localhost:3000,http://localhost:3001"
 
 # Stellar / SEP-10
 STELLAR_SERVER_SECRET="S..." # Server signing keypair secret (Stellar secret key)

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.1.1",
+    "@nestjs/throttler": "^6.3.0",
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "class-transformer": "^0.5.1",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { VerifySignatureDto } from './dto/verify-signature.dto';
 
 @Controller('auth')
+@UseGuards(ThrottlerGuard)
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -12,6 +13,10 @@ import { JwtAuthGuard } from './jwt-auth.guard';
   imports: [
     ConfigModule,
     PrismaModule,
+    ThrottlerModule.forRoot([{
+      ttl: 60000,
+      limit: 10,
+    }]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,7 +6,9 @@ import { ValidationPipe } from '@nestjs/common';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   // CORS
-  app.enableCors();
+  app.enableCors({
+    origin: process.env.CORS_ORIGINS?.split(','),
+  });
 
   // Global validation pipe
   app.useGlobalPipes(


### PR DESCRIPTION
## Description
This PR hardens the creator auth path by introducing rate limiting and CORS configuration for the frontend as requested in the issue.

### Changes Made:
- **CORS Configuration**: Enabled CORS dynamically via the `CORS_ORIGINS` environment variable in `main.ts` so the creator app can call the API safely in both local and production environments.
- **Auth Rate Limiting**: Added `@nestjs/throttler` to rate-limit the SEP-10 challenge and verify endpoints within the auth module to prevent wide-open abuse.
- **Documentation**: Updated the root `README.md` and `backend/.env.example` to document the setup for `CORS_ORIGINS` and `NEXT_PUBLIC_API_URL`.

**Closes #271**
