### PR TITLE
feat(contracts): add quid-badge-nft

### DIFF
--- a/quid-contract/Cargo.lock
+++ b/quid-contract/Cargo.lock
@@ -983,6 +983,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "quid-badge-nft"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "quid-dispute"
 version = "0.0.0"
 dependencies = [

--- a/quid-contract/README.md
+++ b/quid-contract/README.md
@@ -1,6 +1,6 @@
 # Quid Contracts
 
-Soroban (Rust) smart contracts for Quid: bounty escrow, reputation, and milestone programs.
+Soroban (Rust) smart contracts for Quid: bounty escrow, reputation, milestone programs, referrals, disputes, and badges.
 
 ## Contracts
 
@@ -10,6 +10,8 @@ Soroban (Rust) smart contracts for Quid: bounty escrow, reputation, and mileston
 | `quid-reputation` | `quid_reputation.wasm` | Admin, profiles, attestations |
 | `quid-milestone-escrow` | `quid_milestone_escrow.wasm` | Multi-milestone escrow programs |
 | `quid-referral` | `quid_referral.wasm` | Referral attribution + rewards on settled payouts |
+| `quid-dispute` | `quid_dispute.wasm` | Contested-submission arbitration: timelock + optional arbiter |
+| `quid-badge-nft` | `quid_badge_nft.wasm` | Badge NFTs for completed missions / reputation tiers |
 | `hello-world` | `hello_world.wasm` | Scaffold only — safe to ignore |
 
 ## Prerequisites
@@ -38,6 +40,8 @@ target/wasm32v1-none/release/quid_store.wasm
 target/wasm32v1-none/release/quid_reputation.wasm
 target/wasm32v1-none/release/quid_milestone_escrow.wasm
 target/wasm32v1-none/release/quid_referral.wasm
+target/wasm32v1-none/release/quid_dispute.wasm
+target/wasm32v1-none/release/quid_badge_nft.wasm
 ```
 
 ## Deploy (testnet)
@@ -60,6 +64,16 @@ stellar contract deploy \
 
 stellar contract deploy \
   --wasm target/wasm32v1-none/release/quid_referral.wasm \
+  --source alice \
+  --network testnet
+
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/quid_dispute.wasm \
+  --source alice \
+  --network testnet
+
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/quid_badge_nft.wasm \
   --source alice \
   --network testnet
 ```
@@ -145,6 +159,23 @@ See [contracts/quid-referral/README.md](./contracts/quid-referral/README.md).
 - `create_program` / `add_milestone` / `approve_milestone` / `cancel_program`
 - getters for program / milestone status
 
+### `quid-dispute`
+
+- `create_dispute` — hunter opens a case, stakes a bond, sets timelock + optional arbiter
+- `stake_bond` — hunter adds to their bond, or respondent posts a counter-bond
+- `resolve_by_arbiter` — named arbiter awards the pot before the deadline
+- `timeout_release` — after the deadline, refund each party's bond
+- Events: `DisputeCreatedEvent`, `BondStakedEvent`, `DisputeResolvedEvent`, `DisputeTimeoutEvent`
+
+### `quid-badge-nft`
+
+- `initialize` / `get_admin` / `set_admin`
+- `add_minter` / `remove_minter` / `is_minter`
+- `mint_badge` / `get_badge` / `list_by_owner`
+- `transfer` (transferable badges only) / `burn`
+
+See [contracts/quid-badge-nft/README.md](./contracts/quid-badge-nft/README.md).
+
 ## Tests
 
 ```bash
@@ -154,6 +185,8 @@ cargo test -p quid-store
 cargo test -p quid-reputation
 cargo test -p quid-milestone-escrow
 cargo test -p quid-referral
+cargo test -p quid-dispute
+cargo test -p quid-badge-nft
 ```
 
 ## Known gaps (good contributor targets)
@@ -161,165 +194,8 @@ cargo test -p quid-referral
 - `reject_submission` + stake refund on `quid-store`
 - Mission expiry / auto-refund
 - Store → reputation hook on successful payout (also wires `quid-referral.record_payout`)
-- Align milestone status helpers with production auth rules
-- Remove or archive `hello-world`
-
-## Workspace layout
-
-```text
-quid-contract/
-├── Cargo.toml                 # workspace (soroban-sdk 23)
-└── contracts/
-    ├── quid-store/
-    ├── quid-reputation/
-    ├── quid-milestone-escrow/
-    ├── quid-referral/
-    └── hello-world/
-```
-
-## Related docs
-
-- Root: [../README.md](../README.md)
-- Frontend env: [../frontend/README.md](../frontend/README.md)
-- Contributing: [../CONTRIBUTING.md](../CONTRIBUTING.md)
-# Quid Contracts
-
-Soroban (Rust) smart contracts for Quid: bounty escrow, reputation, milestone programs, and disputes.
-
-## Contracts
-
-| Package | Wasm | Role |
-|---------|------|------|
-| `quid-store` | `quid_store.wasm` | Mission bounty vault: create, submit, payout, cancel, pause, slash |
-| `quid-reputation` | `quid_reputation.wasm` | Admin, profiles, attestations |
-| `quid-milestone-escrow` | `quid_milestone_escrow.wasm` | Multi-milestone escrow programs |
-| `quid-dispute` | `quid_dispute.wasm` | Contested-submission arbitration: timelock + optional arbiter |
-| `hello-world` | `hello_world.wasm` | Scaffold only — safe to ignore |
-
-## Prerequisites
-
-- Rust (stable)
-- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools) (`stellar`) — use a version compatible with Soroban SDK 23
-- Testnet account (Friendbot)
-
-```bash
-stellar --version
-stellar keys generate alice --network testnet --as-secret
-stellar keys fund alice --network testnet
-```
-
-## Build
-
-```bash
-cd quid-contract
-stellar contract build
-```
-
-Wasm output:
-
-```text
-target/wasm32v1-none/release/quid_store.wasm
-target/wasm32v1-none/release/quid_reputation.wasm
-target/wasm32v1-none/release/quid_milestone_escrow.wasm
-target/wasm32v1-none/release/quid_dispute.wasm
-```
-
-## Deploy (testnet)
-
-```bash
-stellar contract deploy \
-  --wasm target/wasm32v1-none/release/quid_store.wasm \
-  --source alice \
-  --network testnet
-
-stellar contract deploy \
-  --wasm target/wasm32v1-none/release/quid_reputation.wasm \
-  --source alice \
-  --network testnet
-
-stellar contract deploy \
-  --wasm target/wasm32v1-none/release/quid_milestone_escrow.wasm \
-  --source alice \
-  --network testnet
-
-stellar contract deploy \
-  --wasm target/wasm32v1-none/release/quid_dispute.wasm \
-  --source alice \
-  --network testnet
-```
-
-Copy each `C...` contract ID into `frontend/.env.local`.
-
-### Initialize reputation (once)
-
-```bash
-stellar contract invoke \
-  --id <REPUTATION_CONTRACT_ID> \
-  --source alice \
-  --network testnet \
-  -- \
-  initialize \
-  --admin alice
-```
-
-Verify:
-
-```bash
-stellar contract invoke \
-  --id <REPUTATION_CONTRACT_ID> \
-  --source alice \
-  --network testnet \
-  -- \
-  get_admin
-```
-
-## Main entrypoints
-
-### `quid-store`
-
-- `create_mission` — escrow rewards, optional asset gate
-- `submit_feedback` — hunter stake + IPFS CID
-- `payout_participant` — pay hunter, refund stake
-- `cancel_mission` / `pause_mission` / `update_mission_status`
-- `slash_hunter_stake` / treasury helpers
-
-### `quid-reputation`
-
-- `initialize` / `get_admin`
-- `issue_attestation` / `get_attestation` / `revoke_attestation`
-- `set_profile` / `get_profile`
-
-See [contracts/quid-reputation/README.md](./contracts/quid-reputation/README.md).
-
-### `quid-milestone-escrow`
-
-- `create_program` / `add_milestone` / `approve_milestone` / `cancel_program`
-- getters for program / milestone status
-
-### `quid-dispute`
-
-- `create_dispute` — hunter opens a case, stakes a bond, sets timelock + optional arbiter
-- `stake_bond` — hunter adds to their bond, or respondent posts a counter-bond
-- `resolve_by_arbiter` — named arbiter awards the pot before the deadline
-- `timeout_release` — after the deadline, refund each party's bond
-- Events: `DisputeCreatedEvent`, `BondStakedEvent`, `DisputeResolvedEvent`, `DisputeTimeoutEvent`
-
-## Tests
-
-```bash
-cargo test
-# or per package:
-cargo test -p quid-store
-cargo test -p quid-reputation
-cargo test -p quid-milestone-escrow
-cargo test -p quid-dispute
-```
-
-## Known gaps (good contributor targets)
-
-- `reject_submission` + stake refund on `quid-store`
-- Mission expiry / auto-refund
-- Store → reputation hook on successful payout
+- Store/reputation → `quid-badge-nft` `mint_badge` call on successful payout
+  (the badge contract already exposes the minter allow-list for it)
 - Align milestone status helpers with production auth rules
 - Wire `quid-dispute` into store reject / payout holds
 - Remove or archive `hello-world`
@@ -333,7 +209,9 @@ quid-contract/
     ├── quid-store/
     ├── quid-reputation/
     ├── quid-milestone-escrow/
+    ├── quid-referral/
     ├── quid-dispute/
+    ├── quid-badge-nft/
     └── hello-world/
 ```
 

--- a/quid-contract/contracts/quid-badge-nft/Cargo.toml
+++ b/quid-contract/contracts/quid-badge-nft/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "quid-badge-nft"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/quid-contract/contracts/quid-badge-nft/Makefile
+++ b/quid-contract/contracts/quid-badge-nft/Makefile
@@ -1,0 +1,16 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/quid-contract/contracts/quid-badge-nft/README.md
+++ b/quid-contract/contracts/quid-badge-nft/README.md
@@ -1,0 +1,146 @@
+# Quid Badge NFT Contract
+
+Collectible badge NFTs for completed missions and reputation tiers, so a
+hunter's track record is visible across Stellar apps.
+
+## Features
+
+- Bootstrap a single admin + collection metadata (`initialize`)
+- Minter allow-list: the admin (reputation admin) plus any hooked contract or
+  address, e.g. the `quid-store` payout hook (`add_minter` / `remove_minter`)
+- Mint restricted to the admin or an allow-listed minter (`mint_badge`)
+- IPFS metadata CID per badge, validated non-empty and ≤ 128 chars
+- Soulbound **or** transferable, chosen per badge at mint time
+- One badge per `(recipient, kind, reference)` so a retried payout hook cannot
+  double mint
+- Owner index for `list_by_owner` / `balance_of`
+- Events: `BadgeMintEvent`, `BadgeTransferEvent`, `BadgeBurnEvent`,
+  `MinterAddedEvent`, `MinterRemovedEvent`, `AdminChangedEvent`
+
+## API
+
+### `initialize(env, admin, name, symbol, base_uri) -> Result<(), BadgeError>`
+
+Set the admin and collection metadata. Callable once; admin must authorize.
+`name` and `symbol` must be non-empty. The admin is implicitly a minter.
+
+### `get_admin(env) -> Result<Address, BadgeError>`
+
+### `set_admin(env, new_admin) -> Result<(), BadgeError>`
+
+Hand the admin role over. Current admin must authorize.
+
+### `add_minter(env, minter) -> Result<(), BadgeError>`
+
+Authorize an address to mint. Admin must authorize.
+
+### `remove_minter(env, minter) -> Result<(), BadgeError>`
+
+Revoke minting rights. Admin must authorize. The admin is never on the
+allow-list and always keeps the ability to mint.
+
+### `is_minter(env, address) -> bool`
+
+`true` for the admin and every allow-listed minter.
+
+### `mint_badge(env, minter, to, spec) -> Result<u64, BadgeError>`
+
+Mint a badge to `to` and return its ID. `minter` must authorize and be the
+admin or allow-listed.
+
+| `BadgeSpec` field | Meaning |
+|-------------------|---------|
+| `kind` | `MissionComplete`, `ReputationTier` or `Custom` |
+| `reference` | Mission ID, tier level or campaign ID, depending on `kind` |
+| `metadata_cid` | IPFS CID for the badge artwork / attributes JSON |
+| `soulbound` | `true` = never transferable |
+
+### `get_badge(env, badge_id) -> Result<Badge, BadgeError>`
+
+### `list_by_owner(env, owner) -> Vec<Badge>`
+
+Every badge currently held by `owner`, oldest first. Capped at 256 badges per
+owner so the read stays bounded.
+
+### `list_ids_by_owner(env, owner) -> Vec<u64>`
+
+Cheaper variant that skips the badge reads.
+
+### `owner_of` / `metadata_cid` / `balance_of` / `badge_exists` / `total_minted`
+
+Read helpers. `total_minted` counts mints and does not shrink on burn, since
+badge IDs are monotonic.
+
+### `has_claimed(env, owner, kind, reference) -> bool`
+
+Whether that exact milestone was already awarded to `owner`.
+
+### `collection` / `name` / `symbol` / `base_uri`
+
+Collection metadata. Soroban strings cannot be concatenated on-chain, so
+clients join `base_uri` with a badge's `metadata_cid` off-chain.
+
+### `transfer(env, from, to, badge_id) -> Result<(), BadgeError>`
+
+Move a transferable badge; `from` must authorize and own it. Soulbound badges
+always fail with `SoulboundBadge`. The milestone claim stays with the original
+recipient, so transferring a badge away does not free up a re-mint.
+
+### `burn(env, caller, badge_id) -> Result<(), BadgeError>`
+
+Destroy a badge. Callable by its owner or the admin. Releases the milestone
+claim so an authorized minter can re-issue the badge later.
+
+## Types
+
+```text
+BadgeKind  = MissionComplete | ReputationTier | Custom
+BadgeSpec  { kind, reference, metadata_cid, soulbound }
+Badge      { id, owner, minted_to, kind, reference, metadata_cid, soulbound,
+             minted_at, minted_by }
+Collection { name, symbol, base_uri }
+```
+
+`owner` is the current holder; `minted_to` is the original recipient and is
+what the one-per-milestone guard is keyed on.
+
+## Initialize after deploy
+
+```bash
+stellar contract invoke \
+  --id <BADGE_NFT_CONTRACT_ID> \
+  --source alice \
+  --network testnet \
+  -- \
+  initialize \
+  --admin alice \
+  --name "Quid Badges" \
+  --symbol QBADGE \
+  --base_uri "ipfs://"
+```
+
+Then authorize the reputation / store hook that mints on payout:
+
+```bash
+stellar contract invoke \
+  --id <BADGE_NFT_CONTRACT_ID> \
+  --source alice \
+  --network testnet \
+  -- \
+  add_minter \
+  --minter <STORE_OR_REPUTATION_CONTRACT_ID>
+```
+
+## Known gaps
+
+- No `quid-store` payout → `mint_badge` cross-contract call yet; the hook is
+  expected to be wired on the store side once the payout attestation lands
+- No on-chain `token_uri` (Soroban strings cannot be concatenated); clients
+  join `base_uri` + `metadata_cid`
+- `list_by_owner` caps owners at 256 badges (`OwnerBadgeLimit`)
+
+## Tests
+
+```bash
+cargo test -p quid-badge-nft
+```

--- a/quid-contract/contracts/quid-badge-nft/src/error.rs
+++ b/quid-contract/contracts/quid-badge-nft/src/error.rs
@@ -1,0 +1,25 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BadgeError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    /// Caller is neither the admin nor on the minter allow-list.
+    NotAuthorized = 3,
+    BadgeNotFound = 4,
+    /// This owner already holds a badge for the same (kind, reference) pair.
+    AlreadyMinted = 5,
+    /// Metadata CID is empty or longer than `MAX_CID_LEN`.
+    InvalidMetadata = 6,
+    /// Soulbound badges can never change owner.
+    SoulboundBadge = 7,
+    NotBadgeOwner = 8,
+    SelfTransfer = 9,
+    /// Owner already holds `MAX_BADGES_PER_OWNER` badges.
+    OwnerBadgeLimit = 10,
+    AlreadyMinter = 11,
+    MinterNotFound = 12,
+    /// Collection name or symbol is empty.
+    InvalidCollection = 13,
+}

--- a/quid-contract/contracts/quid-badge-nft/src/lib.rs
+++ b/quid-contract/contracts/quid-badge-nft/src/lib.rs
@@ -1,0 +1,475 @@
+#![no_std]
+use soroban_sdk::{contract, contractevent, contractimpl, Address, Env, String, Vec};
+
+mod error;
+mod types;
+
+pub use error::BadgeError;
+pub use types::{Badge, BadgeKind, BadgeSpec, Collection};
+
+use types::DataKey;
+
+/// ~60 days of ledgers, matching the other Quid contracts.
+const BADGE_TTL_LEDGERS: u32 = 5_184_000;
+
+/// A base32 CIDv1 is 59 chars; this leaves headroom without allowing
+/// unbounded metadata to be written into ledger state.
+const MAX_CID_LEN: u32 = 128;
+
+/// Caps the per-owner index so `list_by_owner` stays bounded.
+const MAX_BADGES_PER_OWNER: u32 = 256;
+
+#[contractevent(topics = ["badge", "mint"])]
+pub struct BadgeMintEvent {
+    pub badge_id: u64,
+    pub to: Address,
+    pub minter: Address,
+}
+
+#[contractevent(topics = ["badge", "transfer"])]
+pub struct BadgeTransferEvent {
+    pub badge_id: u64,
+    pub from: Address,
+    pub to: Address,
+}
+
+#[contractevent(topics = ["badge", "burn"])]
+pub struct BadgeBurnEvent {
+    pub badge_id: u64,
+    pub owner: Address,
+}
+
+#[contractevent(topics = ["minter", "added"], data_format = "single-value")]
+pub struct MinterAddedEvent {
+    pub minter: Address,
+}
+
+#[contractevent(topics = ["minter", "removed"], data_format = "single-value")]
+pub struct MinterRemovedEvent {
+    pub minter: Address,
+}
+
+#[contractevent(topics = ["admin", "changed"])]
+pub struct AdminChangedEvent {
+    pub previous_admin: Address,
+    pub new_admin: Address,
+}
+
+/// Badge NFTs for completed missions and reputation tiers.
+///
+/// Minting is restricted to an allow-list of minters (the reputation admin and
+/// the `quid-store` payout hook), each badge carries an IPFS metadata CID, and
+/// badges may be minted soulbound (never transferable) or transferable.
+#[contract]
+pub struct QuidBadgeNftContract;
+
+#[contractimpl]
+impl QuidBadgeNftContract {
+    // -------------------------------------------------------------------------
+    // Admin bootstrap
+    // -------------------------------------------------------------------------
+
+    /// Set the admin and collection metadata. Callable once; admin must authorize.
+    /// The admin is implicitly a minter and manages the minter allow-list.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        name: String,
+        symbol: String,
+        base_uri: String,
+    ) -> Result<(), BadgeError> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(BadgeError::AlreadyInitialized);
+        }
+
+        if name.is_empty() || symbol.is_empty() {
+            return Err(BadgeError::InvalidCollection);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(
+            &DataKey::Collection,
+            &Collection {
+                name,
+                symbol,
+                base_uri,
+            },
+        );
+
+        Ok(())
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, BadgeError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(BadgeError::NotInitialized)
+    }
+
+    /// Hand the admin role to another address. Current admin must authorize.
+    pub fn set_admin(env: Env, new_admin: Address) -> Result<(), BadgeError> {
+        let previous_admin = Self::get_admin(env.clone())?;
+        previous_admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+
+        AdminChangedEvent {
+            previous_admin,
+            new_admin,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Collection metadata (SEP-41 style getters)
+    // -------------------------------------------------------------------------
+
+    pub fn collection(env: Env) -> Result<Collection, BadgeError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Collection)
+            .ok_or(BadgeError::NotInitialized)
+    }
+
+    pub fn name(env: Env) -> Result<String, BadgeError> {
+        Ok(Self::collection(env)?.name)
+    }
+
+    pub fn symbol(env: Env) -> Result<String, BadgeError> {
+        Ok(Self::collection(env)?.symbol)
+    }
+
+    /// Gateway prefix to join with a badge's `metadata_cid` off-chain.
+    pub fn base_uri(env: Env) -> Result<String, BadgeError> {
+        Ok(Self::collection(env)?.base_uri)
+    }
+
+    // -------------------------------------------------------------------------
+    // Minter allow-list
+    // -------------------------------------------------------------------------
+
+    /// Authorize an address to mint badges (e.g. the `quid-store` payout hook).
+    /// Admin must authorize.
+    pub fn add_minter(env: Env, minter: Address) -> Result<(), BadgeError> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        let key = DataKey::Minter(minter.clone());
+        if env.storage().persistent().has(&key) {
+            return Err(BadgeError::AlreadyMinter);
+        }
+
+        env.storage().persistent().set(&key, &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BADGE_TTL_LEDGERS, BADGE_TTL_LEDGERS);
+
+        MinterAddedEvent { minter }.publish(&env);
+
+        Ok(())
+    }
+
+    /// Revoke minting rights. Admin must authorize. The admin itself always
+    /// keeps the ability to mint and is not stored on the allow-list.
+    pub fn remove_minter(env: Env, minter: Address) -> Result<(), BadgeError> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        let key = DataKey::Minter(minter.clone());
+        if !env.storage().persistent().has(&key) {
+            return Err(BadgeError::MinterNotFound);
+        }
+
+        env.storage().persistent().remove(&key);
+
+        MinterRemovedEvent { minter }.publish(&env);
+
+        Ok(())
+    }
+
+    /// `true` for the admin and for every allow-listed minter.
+    pub fn is_minter(env: Env, address: Address) -> bool {
+        match env.storage().instance().get::<_, Address>(&DataKey::Admin) {
+            Some(admin) if admin == address => true,
+            Some(_) => env.storage().persistent().has(&DataKey::Minter(address)),
+            None => false,
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Minting
+    // -------------------------------------------------------------------------
+
+    /// Mint a badge to `to`. Only the admin or an allow-listed minter may call,
+    /// and each recipient can hold at most one badge per `(kind, reference)`
+    /// pair so a retried payout hook cannot double mint.
+    pub fn mint_badge(
+        env: Env,
+        minter: Address,
+        to: Address,
+        spec: BadgeSpec,
+    ) -> Result<u64, BadgeError> {
+        minter.require_auth();
+        Self::require_minter(&env, &minter)?;
+        Self::validate_cid(&spec.metadata_cid)?;
+
+        let claim_key = DataKey::Claimed(to.clone(), spec.kind, spec.reference);
+        if env.storage().persistent().has(&claim_key) {
+            return Err(BadgeError::AlreadyMinted);
+        }
+
+        let badge_id = Self::get_next_badge_id(&env);
+
+        let badge = Badge {
+            id: badge_id,
+            owner: to.clone(),
+            minted_to: to.clone(),
+            kind: spec.kind,
+            reference: spec.reference,
+            metadata_cid: spec.metadata_cid,
+            soulbound: spec.soulbound,
+            minted_at: env.ledger().timestamp(),
+            minted_by: minter.clone(),
+        };
+
+        Self::write_badge(&env, &badge);
+        Self::index_add(&env, &to, badge_id)?;
+
+        env.storage().persistent().set(&claim_key, &badge_id);
+        env.storage()
+            .persistent()
+            .extend_ttl(&claim_key, BADGE_TTL_LEDGERS, BADGE_TTL_LEDGERS);
+
+        BadgeMintEvent {
+            badge_id,
+            to,
+            minter,
+        }
+        .publish(&env);
+
+        Ok(badge_id)
+    }
+
+    // -------------------------------------------------------------------------
+    // Reads
+    // -------------------------------------------------------------------------
+
+    pub fn get_badge(env: Env, badge_id: u64) -> Result<Badge, BadgeError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Badge(badge_id))
+            .ok_or(BadgeError::BadgeNotFound)
+    }
+
+    /// Every badge currently held by `owner`, oldest first.
+    pub fn list_by_owner(env: Env, owner: Address) -> Vec<Badge> {
+        let mut badges = Vec::new(&env);
+
+        for badge_id in Self::owned_ids(&env, &owner).iter() {
+            if let Some(badge) = env
+                .storage()
+                .persistent()
+                .get::<_, Badge>(&DataKey::Badge(badge_id))
+            {
+                badges.push_back(badge);
+            }
+        }
+
+        badges
+    }
+
+    /// Cheaper variant of [`Self::list_by_owner`] that skips the badge reads.
+    pub fn list_ids_by_owner(env: Env, owner: Address) -> Vec<u64> {
+        Self::owned_ids(&env, &owner)
+    }
+
+    pub fn owner_of(env: Env, badge_id: u64) -> Result<Address, BadgeError> {
+        Ok(Self::get_badge(env, badge_id)?.owner)
+    }
+
+    pub fn metadata_cid(env: Env, badge_id: u64) -> Result<String, BadgeError> {
+        Ok(Self::get_badge(env, badge_id)?.metadata_cid)
+    }
+
+    pub fn balance_of(env: Env, owner: Address) -> u32 {
+        Self::owned_ids(&env, &owner).len()
+    }
+
+    /// Badge ids are monotonic, so this counts mints and does not shrink on burn.
+    pub fn total_minted(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::BadgeCount)
+            .unwrap_or(0)
+    }
+
+    pub fn badge_exists(env: Env, badge_id: u64) -> bool {
+        env.storage().persistent().has(&DataKey::Badge(badge_id))
+    }
+
+    /// Whether `owner` was already awarded this exact milestone.
+    pub fn has_claimed(env: Env, owner: Address, kind: BadgeKind, reference: u64) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Claimed(owner, kind, reference))
+    }
+
+    // -------------------------------------------------------------------------
+    // Transfer / burn
+    // -------------------------------------------------------------------------
+
+    /// Move a transferable badge. Soulbound badges always fail with
+    /// [`BadgeError::SoulboundBadge`]. The one-per-milestone guard stays with
+    /// the original recipient, so transferring does not free up a re-mint.
+    pub fn transfer(env: Env, from: Address, to: Address, badge_id: u64) -> Result<(), BadgeError> {
+        from.require_auth();
+
+        let mut badge = Self::get_badge(env.clone(), badge_id)?;
+
+        if badge.owner != from {
+            return Err(BadgeError::NotBadgeOwner);
+        }
+        if badge.soulbound {
+            return Err(BadgeError::SoulboundBadge);
+        }
+        if from == to {
+            return Err(BadgeError::SelfTransfer);
+        }
+
+        Self::index_add(&env, &to, badge_id)?;
+        Self::index_remove(&env, &from, badge_id);
+
+        badge.owner = to.clone();
+        Self::write_badge(&env, &badge);
+
+        BadgeTransferEvent { badge_id, from, to }.publish(&env);
+
+        Ok(())
+    }
+
+    /// Destroy a badge. Callable by its owner or the admin. The milestone claim
+    /// is released so an authorized minter can re-issue the badge later.
+    pub fn burn(env: Env, caller: Address, badge_id: u64) -> Result<(), BadgeError> {
+        caller.require_auth();
+
+        let badge = Self::get_badge(env.clone(), badge_id)?;
+        let admin = Self::get_admin(env.clone())?;
+
+        if caller != badge.owner && caller != admin {
+            return Err(BadgeError::NotAuthorized);
+        }
+
+        env.storage().persistent().remove(&DataKey::Badge(badge_id));
+        Self::index_remove(&env, &badge.owner, badge_id);
+        env.storage().persistent().remove(&DataKey::Claimed(
+            badge.minted_to,
+            badge.kind,
+            badge.reference,
+        ));
+
+        BadgeBurnEvent {
+            badge_id,
+            owner: badge.owner,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    fn require_minter(env: &Env, caller: &Address) -> Result<(), BadgeError> {
+        let admin = Self::get_admin(env.clone())?;
+
+        if *caller == admin {
+            return Ok(());
+        }
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Minter(caller.clone()))
+        {
+            return Ok(());
+        }
+
+        Err(BadgeError::NotAuthorized)
+    }
+
+    fn validate_cid(metadata_cid: &String) -> Result<(), BadgeError> {
+        if metadata_cid.is_empty() || metadata_cid.len() > MAX_CID_LEN {
+            return Err(BadgeError::InvalidMetadata);
+        }
+        Ok(())
+    }
+
+    fn get_next_badge_id(env: &Env) -> u64 {
+        let mut count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::BadgeCount)
+            .unwrap_or(0);
+        count += 1;
+        env.storage().instance().set(&DataKey::BadgeCount, &count);
+        count
+    }
+
+    fn write_badge(env: &Env, badge: &Badge) {
+        let key = DataKey::Badge(badge.id);
+        env.storage().persistent().set(&key, badge);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BADGE_TTL_LEDGERS, BADGE_TTL_LEDGERS);
+    }
+
+    fn owned_ids(env: &Env, owner: &Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Owned(owner.clone()))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Append `badge_id` to an owner's index. Returning an error reverts the
+    /// whole invocation, so a rejected mint leaves no partial state behind.
+    fn index_add(env: &Env, owner: &Address, badge_id: u64) -> Result<(), BadgeError> {
+        let mut owned = Self::owned_ids(env, owner);
+
+        if owned.len() >= MAX_BADGES_PER_OWNER {
+            return Err(BadgeError::OwnerBadgeLimit);
+        }
+
+        owned.push_back(badge_id);
+        Self::write_owned(env, owner, &owned);
+
+        Ok(())
+    }
+
+    fn index_remove(env: &Env, owner: &Address, badge_id: u64) {
+        let owned = Self::owned_ids(env, owner);
+        let mut remaining = Vec::new(env);
+
+        for id in owned.iter() {
+            if id != badge_id {
+                remaining.push_back(id);
+            }
+        }
+
+        Self::write_owned(env, owner, &remaining);
+    }
+
+    fn write_owned(env: &Env, owner: &Address, owned: &Vec<u64>) {
+        let key = DataKey::Owned(owner.clone());
+        env.storage().persistent().set(&key, owned);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BADGE_TTL_LEDGERS, BADGE_TTL_LEDGERS);
+    }
+}
+
+mod test;

--- a/quid-contract/contracts/quid-badge-nft/src/test.rs
+++ b/quid-contract/contracts/quid-badge-nft/src/test.rs
@@ -1,0 +1,515 @@
+#![cfg(test)]
+
+use crate::{
+    error::BadgeError,
+    types::{BadgeKind, BadgeSpec},
+    QuidBadgeNftContract, QuidBadgeNftContractClient,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup() -> (Env, QuidBadgeNftContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuidBadgeNftContract, ());
+    let client = QuidBadgeNftContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Quid Badges"),
+        &String::from_str(&env, "QBADGE"),
+        &String::from_str(&env, "ipfs://"),
+    );
+
+    (env, client, admin)
+}
+
+fn mission_badge(env: &Env, mission_id: u64, soulbound: bool) -> BadgeSpec {
+    BadgeSpec {
+        kind: BadgeKind::MissionComplete,
+        reference: mission_id,
+        metadata_cid: String::from_str(env, "QmBadgeMetadataCid"),
+        soulbound,
+    }
+}
+
+// -------------------------------------------------------------------------
+// Admin bootstrap
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_sets_admin_and_collection() {
+    let (env, client, admin) = setup();
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.name(), String::from_str(&env, "Quid Badges"));
+    assert_eq!(client.symbol(), String::from_str(&env, "QBADGE"));
+    assert_eq!(client.base_uri(), String::from_str(&env, "ipfs://"));
+    assert_eq!(client.total_minted(), 0);
+}
+
+#[test]
+fn test_initialize_twice_fails() {
+    let (env, client, _admin) = setup();
+    let other = Address::generate(&env);
+
+    assert_eq!(
+        client.try_initialize(
+            &other,
+            &String::from_str(&env, "Copy"),
+            &String::from_str(&env, "CPY"),
+            &String::from_str(&env, "ipfs://"),
+        ),
+        Err(Ok(BadgeError::AlreadyInitialized))
+    );
+}
+
+#[test]
+fn test_initialize_rejects_empty_symbol() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuidBadgeNftContract, ());
+    let client = QuidBadgeNftContractClient::new(&env, &contract_id);
+
+    assert_eq!(
+        client.try_initialize(
+            &Address::generate(&env),
+            &String::from_str(&env, "Quid Badges"),
+            &String::from_str(&env, ""),
+            &String::from_str(&env, "ipfs://"),
+        ),
+        Err(Ok(BadgeError::InvalidCollection))
+    );
+}
+
+#[test]
+fn test_uninitialized_contract_has_no_admin() {
+    let env = Env::default();
+    let contract_id = env.register(QuidBadgeNftContract, ());
+    let client = QuidBadgeNftContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.try_get_admin(), Err(Ok(BadgeError::NotInitialized)));
+    assert!(!client.is_minter(&Address::generate(&env)));
+}
+
+#[test]
+fn test_set_admin_moves_role() {
+    let (env, client, admin) = setup();
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&new_admin);
+
+    assert_eq!(client.get_admin(), new_admin);
+    assert!(client.is_minter(&new_admin));
+    assert!(!client.is_minter(&admin));
+}
+
+// -------------------------------------------------------------------------
+// Minter allow-list
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_admin_is_minter_by_default() {
+    let (_env, client, admin) = setup();
+
+    assert!(client.is_minter(&admin));
+}
+
+#[test]
+fn test_add_and_remove_minter() {
+    let (env, client, _admin) = setup();
+    let store_hook = Address::generate(&env);
+
+    assert!(!client.is_minter(&store_hook));
+
+    client.add_minter(&store_hook);
+    assert!(client.is_minter(&store_hook));
+
+    client.remove_minter(&store_hook);
+    assert!(!client.is_minter(&store_hook));
+}
+
+#[test]
+fn test_add_minter_twice_fails() {
+    let (env, client, _admin) = setup();
+    let store_hook = Address::generate(&env);
+
+    client.add_minter(&store_hook);
+
+    assert_eq!(
+        client.try_add_minter(&store_hook),
+        Err(Ok(BadgeError::AlreadyMinter))
+    );
+}
+
+#[test]
+fn test_remove_unknown_minter_fails() {
+    let (env, client, _admin) = setup();
+
+    assert_eq!(
+        client.try_remove_minter(&Address::generate(&env)),
+        Err(Ok(BadgeError::MinterNotFound))
+    );
+}
+
+// -------------------------------------------------------------------------
+// Minting
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_admin_mints_badge_with_metadata_cid() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+
+    let badge_id = client.mint_badge(&admin, &hunter, &mission_badge(&env, 42, true));
+
+    assert_eq!(badge_id, 1);
+    assert_eq!(client.total_minted(), 1);
+    assert!(client.badge_exists(&badge_id));
+
+    let badge = client.get_badge(&badge_id);
+    assert_eq!(badge.id, 1);
+    assert_eq!(badge.owner, hunter);
+    assert_eq!(badge.minted_to, hunter);
+    assert_eq!(badge.minted_by, admin);
+    assert_eq!(badge.kind, BadgeKind::MissionComplete);
+    assert_eq!(badge.reference, 42);
+    assert_eq!(
+        badge.metadata_cid,
+        String::from_str(&env, "QmBadgeMetadataCid")
+    );
+    assert!(badge.soulbound);
+    assert_eq!(badge.minted_at, env.ledger().timestamp());
+
+    assert_eq!(client.owner_of(&badge_id), hunter);
+    assert_eq!(
+        client.metadata_cid(&badge_id),
+        String::from_str(&env, "QmBadgeMetadataCid")
+    );
+}
+
+#[test]
+fn test_allow_listed_minter_can_mint() {
+    let (env, client, _admin) = setup();
+    let store_hook = Address::generate(&env);
+    let hunter = Address::generate(&env);
+
+    client.add_minter(&store_hook);
+    let badge_id = client.mint_badge(&store_hook, &hunter, &mission_badge(&env, 7, true));
+
+    assert_eq!(client.get_badge(&badge_id).minted_by, store_hook);
+}
+
+#[test]
+fn test_mint_rejected_for_unauthorized_caller() {
+    let (env, client, _admin) = setup();
+    let stranger = Address::generate(&env);
+    let hunter = Address::generate(&env);
+
+    assert_eq!(
+        client.try_mint_badge(&stranger, &hunter, &mission_badge(&env, 1, true)),
+        Err(Ok(BadgeError::NotAuthorized))
+    );
+    assert_eq!(client.total_minted(), 0);
+    assert_eq!(client.balance_of(&hunter), 0);
+}
+
+#[test]
+fn test_mint_rejected_after_minter_revoked() {
+    let (env, client, _admin) = setup();
+    let store_hook = Address::generate(&env);
+    let hunter = Address::generate(&env);
+
+    client.add_minter(&store_hook);
+    client.mint_badge(&store_hook, &hunter, &mission_badge(&env, 1, true));
+    client.remove_minter(&store_hook);
+
+    assert_eq!(
+        client.try_mint_badge(&store_hook, &hunter, &mission_badge(&env, 2, true)),
+        Err(Ok(BadgeError::NotAuthorized))
+    );
+}
+
+#[test]
+fn test_mint_requires_minter_authorization() {
+    let env = Env::default();
+    let contract_id = env.register(QuidBadgeNftContract, ());
+    let client = QuidBadgeNftContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Quid Badges"),
+        &String::from_str(&env, "QBADGE"),
+        &String::from_str(&env, "ipfs://"),
+    );
+
+    // Drop the mocks: mint_badge must now fail on `minter.require_auth()`.
+    env.set_auths(&[]);
+
+    let hunter = Address::generate(&env);
+    assert!(client
+        .try_mint_badge(&admin, &hunter, &mission_badge(&env, 1, true))
+        .is_err());
+    assert_eq!(client.total_minted(), 0);
+}
+
+#[test]
+fn test_duplicate_milestone_badge_rejected() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+
+    client.mint_badge(&admin, &hunter, &mission_badge(&env, 42, true));
+
+    assert!(client.has_claimed(&hunter, &BadgeKind::MissionComplete, &42));
+    assert_eq!(
+        client.try_mint_badge(&admin, &hunter, &mission_badge(&env, 42, true)),
+        Err(Ok(BadgeError::AlreadyMinted))
+    );
+    assert_eq!(client.balance_of(&hunter), 1);
+}
+
+#[test]
+fn test_same_reference_different_kind_is_allowed() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+
+    client.mint_badge(&admin, &hunter, &mission_badge(&env, 3, true));
+    client.mint_badge(
+        &admin,
+        &hunter,
+        &BadgeSpec {
+            kind: BadgeKind::ReputationTier,
+            reference: 3,
+            metadata_cid: String::from_str(&env, "QmTierThree"),
+            soulbound: true,
+        },
+    );
+
+    assert_eq!(client.balance_of(&hunter), 2);
+}
+
+#[test]
+fn test_same_milestone_for_two_hunters_is_allowed() {
+    let (env, client, admin) = setup();
+    let first = Address::generate(&env);
+    let second = Address::generate(&env);
+
+    client.mint_badge(&admin, &first, &mission_badge(&env, 9, true));
+    client.mint_badge(&admin, &second, &mission_badge(&env, 9, true));
+
+    assert_eq!(client.balance_of(&first), 1);
+    assert_eq!(client.balance_of(&second), 1);
+    assert_eq!(client.total_minted(), 2);
+}
+
+#[test]
+fn test_mint_rejects_empty_metadata_cid() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+
+    let spec = BadgeSpec {
+        kind: BadgeKind::MissionComplete,
+        reference: 1,
+        metadata_cid: String::from_str(&env, ""),
+        soulbound: true,
+    };
+
+    assert_eq!(
+        client.try_mint_badge(&admin, &hunter, &spec),
+        Err(Ok(BadgeError::InvalidMetadata))
+    );
+}
+
+#[test]
+fn test_mint_rejects_oversized_metadata_cid() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+
+    // 129 chars, one over MAX_CID_LEN.
+    let long_cid = "Qm1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567";
+    assert_eq!(long_cid.len(), 129);
+
+    let spec = BadgeSpec {
+        kind: BadgeKind::Custom,
+        reference: 1,
+        metadata_cid: String::from_str(&env, long_cid),
+        soulbound: false,
+    };
+
+    assert_eq!(
+        client.try_mint_badge(&admin, &hunter, &spec),
+        Err(Ok(BadgeError::InvalidMetadata))
+    );
+}
+
+#[test]
+fn test_get_missing_badge_fails() {
+    let (_env, client, _admin) = setup();
+
+    assert_eq!(
+        client.try_get_badge(&404),
+        Err(Ok(BadgeError::BadgeNotFound))
+    );
+    assert!(!client.badge_exists(&404));
+}
+
+// -------------------------------------------------------------------------
+// list_by_owner
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_list_by_owner_returns_only_that_owners_badges() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    let first = client.mint_badge(&admin, &hunter, &mission_badge(&env, 1, true));
+    let second = client.mint_badge(&admin, &hunter, &mission_badge(&env, 2, true));
+    let third = client.mint_badge(&admin, &other, &mission_badge(&env, 3, true));
+
+    let badges = client.list_by_owner(&hunter);
+    assert_eq!(badges.len(), 2);
+    assert_eq!(badges.get(0).unwrap().id, first);
+    assert_eq!(badges.get(1).unwrap().id, second);
+    assert_eq!(
+        client.list_ids_by_owner(&hunter),
+        soroban_sdk::vec![&env, first, second]
+    );
+
+    let other_badges = client.list_by_owner(&other);
+    assert_eq!(other_badges.len(), 1);
+    assert_eq!(other_badges.get(0).unwrap().id, third);
+}
+
+#[test]
+fn test_list_by_owner_empty_for_unknown_address() {
+    let (env, client, _admin) = setup();
+
+    assert_eq!(client.list_by_owner(&Address::generate(&env)).len(), 0);
+    assert_eq!(client.balance_of(&Address::generate(&env)), 0);
+}
+
+// -------------------------------------------------------------------------
+// Transfer / burn
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_transfer_moves_transferable_badge() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    let badge_id = client.mint_badge(&admin, &hunter, &mission_badge(&env, 5, false));
+
+    client.transfer(&hunter, &collector, &badge_id);
+
+    assert_eq!(client.owner_of(&badge_id), collector);
+    assert_eq!(client.balance_of(&hunter), 0);
+    assert_eq!(client.balance_of(&collector), 1);
+    assert_eq!(client.list_by_owner(&hunter).len(), 0);
+    assert_eq!(
+        client.list_by_owner(&collector).get(0).unwrap().id,
+        badge_id
+    );
+
+    // The milestone stays claimed by the original recipient after a transfer.
+    let badge = client.get_badge(&badge_id);
+    assert_eq!(badge.minted_to, hunter);
+    assert!(client.has_claimed(&hunter, &BadgeKind::MissionComplete, &5));
+    assert_eq!(
+        client.try_mint_badge(&admin, &hunter, &mission_badge(&env, 5, false)),
+        Err(Ok(BadgeError::AlreadyMinted))
+    );
+}
+
+#[test]
+fn test_transfer_of_soulbound_badge_rejected() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    let badge_id = client.mint_badge(&admin, &hunter, &mission_badge(&env, 5, true));
+
+    assert_eq!(
+        client.try_transfer(&hunter, &collector, &badge_id),
+        Err(Ok(BadgeError::SoulboundBadge))
+    );
+    assert_eq!(client.owner_of(&badge_id), hunter);
+}
+
+#[test]
+fn test_transfer_by_non_owner_rejected() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    let badge_id = client.mint_badge(&admin, &hunter, &mission_badge(&env, 5, false));
+
+    assert_eq!(
+        client.try_transfer(&stranger, &stranger, &badge_id),
+        Err(Ok(BadgeError::NotBadgeOwner))
+    );
+}
+
+#[test]
+fn test_self_transfer_rejected() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+
+    let badge_id = client.mint_badge(&admin, &hunter, &mission_badge(&env, 5, false));
+
+    assert_eq!(
+        client.try_transfer(&hunter, &hunter, &badge_id),
+        Err(Ok(BadgeError::SelfTransfer))
+    );
+    assert_eq!(client.balance_of(&hunter), 1);
+}
+
+#[test]
+fn test_owner_can_burn_and_badge_can_be_reissued() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+
+    let badge_id = client.mint_badge(&admin, &hunter, &mission_badge(&env, 8, true));
+
+    client.burn(&hunter, &badge_id);
+
+    assert!(!client.badge_exists(&badge_id));
+    assert_eq!(client.balance_of(&hunter), 0);
+    assert!(!client.has_claimed(&hunter, &BadgeKind::MissionComplete, &8));
+
+    let reissued = client.mint_badge(&admin, &hunter, &mission_badge(&env, 8, true));
+    assert_eq!(reissued, 2);
+    assert_eq!(client.total_minted(), 2);
+}
+
+#[test]
+fn test_admin_can_burn_any_badge() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+
+    let badge_id = client.mint_badge(&admin, &hunter, &mission_badge(&env, 8, true));
+
+    client.burn(&admin, &badge_id);
+
+    assert!(!client.badge_exists(&badge_id));
+}
+
+#[test]
+fn test_burn_by_stranger_rejected() {
+    let (env, client, admin) = setup();
+    let hunter = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    let badge_id = client.mint_badge(&admin, &hunter, &mission_badge(&env, 8, true));
+
+    assert_eq!(
+        client.try_burn(&stranger, &badge_id),
+        Err(Ok(BadgeError::NotAuthorized))
+    );
+    assert!(client.badge_exists(&badge_id));
+}

--- a/quid-contract/contracts/quid-badge-nft/src/types.rs
+++ b/quid-contract/contracts/quid-badge-nft/src/types.rs
@@ -1,0 +1,75 @@
+use soroban_sdk::{contracttype, Address, String};
+
+/// What a badge was awarded for. `reference` on the badge disambiguates the
+/// individual award inside a kind.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Copy)]
+#[contracttype]
+pub enum BadgeKind {
+    /// Awarded on a paid-out mission submission. `reference` = mission id.
+    #[default]
+    MissionComplete,
+    /// Awarded when a hunter crosses a reputation tier. `reference` = tier level.
+    ReputationTier,
+    /// Anything else the reputation admin wants to hand out.
+    /// `reference` = campaign / season id.
+    Custom,
+}
+
+/// Collection level metadata, set once at initialization.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Collection {
+    pub name: String,
+    pub symbol: String,
+    /// Gateway prefix for `Badge::metadata_cid` (e.g. `ipfs://`). Clients join
+    /// the two off-chain; Soroban strings cannot be concatenated on-chain.
+    pub base_uri: String,
+}
+
+/// Mint arguments describing the badge itself, kept in one struct so
+/// `mint_badge` stays a four argument call.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BadgeSpec {
+    pub kind: BadgeKind,
+    pub reference: u64,
+    /// IPFS CID of the badge artwork / attributes JSON.
+    pub metadata_cid: String,
+    /// `true` makes the badge non-transferable for its whole life.
+    pub soulbound: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Badge {
+    pub id: u64,
+    /// Current holder. Equal to `minted_to` until a transferable badge moves.
+    pub owner: Address,
+    /// Original recipient, kept so the one-per-milestone guard survives transfers.
+    pub minted_to: Address,
+    pub kind: BadgeKind,
+    pub reference: u64,
+    pub metadata_cid: String,
+    pub soulbound: bool,
+    pub minted_at: u64,
+    pub minted_by: Address,
+}
+
+#[contracttype]
+pub enum DataKey {
+    /// Admin address; manages the minter allow-list and may always mint.
+    Admin,
+    /// Collection name / symbol / base URI.
+    Collection,
+    /// Minter allow-list entry (reputation admin, quid-store payout hook, ...).
+    Minter(Address),
+    /// Badge record by id.
+    Badge(u64),
+    /// Monotonic badge id counter; never decremented on burn.
+    BadgeCount,
+    /// Badge ids held by an address, for `list_by_owner`.
+    Owned(Address),
+    /// Uniqueness guard so a retried payout hook cannot double mint:
+    /// (original recipient, kind, reference) -> badge id.
+    Claimed(Address, BadgeKind, u64),
+}


### PR DESCRIPTION
Closes #297 

## Summary

New `quid-badge-nft` crate: soulbound-or-transferable badge NFTs awarded for
completed missions and reputation tiers, so a hunter's work is visible across
Stellar apps.

Minting is gated behind an allow-list rather than a single hardcoded address,
so both intended minters from the issue work: the reputation admin (implicitly
a minter) and a hooked `quid-store` payout contract added via `add_minter`.

## API

| Function | Notes |
|----------|-------|
| `initialize(admin, name, symbol, base_uri)` | Once; admin must authorize |
| `get_admin` / `set_admin` | Admin handover |
| `add_minter` / `remove_minter` / `is_minter` | Allow-list, admin-only writes |
| `mint_badge(minter, to, spec)` | Returns badge ID; minter must authorize |
| `get_badge` / `list_by_owner` / `list_ids_by_owner` | Reads |
| `owner_of` / `metadata_cid` / `balance_of` / `badge_exists` / `total_minted` / `has_claimed` | Helpers |
| `collection` / `name` / `symbol` / `base_uri` | SEP-41 style metadata getters |
| `transfer(from, to, badge_id)` | Fails `SoulboundBadge` for soulbound badges |
| `burn(caller, badge_id)` | Owner or admin |

`BadgeSpec { kind, reference, metadata_cid, soulbound }` — `kind` is
`MissionComplete` / `ReputationTier` / `Custom`, and `reference` is the
mission ID, tier level or campaign ID accordingly.

## Acceptance criteria

- [x] **Mint restricted to authorized minter** — `mint_badge` requires
      `minter.require_auth()` *and* that the caller is the admin or
      allow-listed; otherwise `NotAuthorized`.
- [x] **Metadata CID supported** — per-badge `metadata_cid` validated
      non-empty and ≤ 128 chars, plus a collection `base_uri`.
- [x] **Tests included** — 29 unit tests.

## Design notes

- **Soulbound *and* transferable.** The issue left this open, so `soulbound` is
  a per-badge flag chosen at mint: milestone badges can be permanent while
  collectibles stay tradeable.
- **Double-mint guard.** One badge per `(recipient, kind, reference)`. A payout
  hook that retries cannot mint twice. The claim is keyed on `minted_to` (the
  original recipient), so transferring a badge away does not free up a re-mint;
  `burn` releases it so a minter can legitimately re-issue.
- **Bounded reads.** The per-owner index is capped at 256 badges
  (`OwnerBadgeLimit`) so `list_by_owner` never becomes unbounded, per the
  gas-optimization guidance in CONTRIBUTING.md.
- **No `token_uri`.** Soroban strings cannot be concatenated on-chain; clients
  join `base_uri` with `metadata_cid` off-chain.
- No `.unwrap()` in contract code; all fallible paths return
  `Result<T, BadgeError>`.

## Dependency status

This issue depends on the store payout → reputation attestation hook. No payout
hook exists on the store side yet, so **no cross-contract call is wired here**.
The badge contract exposes the minter allow-list that hook will use; the gap is
recorded in both READMEs' "Known gaps".

## Test results

