### PR TITLE
feat(contracts): add quid-dispute contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Founders launch dApps into quiet Discords. Real users rarely spend 20 minutes te
 |------|---------------------|
 | `frontend/` | Next.js UI, Freighter, creator/hunter flows |
 | `backend/` | NestJS auth, mission index, IPFS upload, indexer |
-| `quid-contract/` | Soroban contracts (`quid-store`, reputation, milestone escrow) |
+| `quid-contract/` | Soroban contracts (`quid-store`, reputation, milestone escrow, dispute) |
 
 Read the README in each package before starting.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Quid is a feedback marketplace on **Stellar / Soroban**. Founders lock USDC/XLM 
 Quid/
 ├── frontend/          # Next.js app (Freighter, creator + hunter UI)
 ├── backend/           # NestJS API (auth, missions index, upload, indexer)
-├── quid-contract/     # Soroban contracts (store, reputation, milestone escrow)
+├── quid-contract/     # Soroban contracts (store, reputation, milestone escrow, dispute)
 └── CONTRIBUTING.md
 ```
 
@@ -46,7 +46,7 @@ Frontend (Next.js) ──────► Backend (NestJS + Postgres)
       │ create / submit / pay   │ index events, drafts, IPFS
       ▼                         ▼
 Soroban contracts ◄─────────────┘
-(quid-store, quid-reputation, quid-milestone-escrow)
+(quid-store, quid-reputation, quid-milestone-escrow, quid-dispute)
       │
       ▼
 IPFS (feedback blobs; CID stored on-chain)

--- a/quid-contract/Cargo.lock
+++ b/quid-contract/Cargo.lock
@@ -983,6 +983,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "quid-dispute"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "quid-milestone-escrow"
 version = "0.0.0"
 dependencies = [

--- a/quid-contract/README.md
+++ b/quid-contract/README.md
@@ -1,6 +1,6 @@
 # Quid Contracts
 
-Soroban (Rust) smart contracts for Quid: bounty escrow, reputation, and milestone programs.
+Soroban (Rust) smart contracts for Quid: bounty escrow, reputation, milestone programs, and disputes.
 
 ## Contracts
 
@@ -9,6 +9,7 @@ Soroban (Rust) smart contracts for Quid: bounty escrow, reputation, and mileston
 | `quid-store` | `quid_store.wasm` | Mission bounty vault: create, submit, payout, cancel, pause, slash |
 | `quid-reputation` | `quid_reputation.wasm` | Admin, profiles, attestations |
 | `quid-milestone-escrow` | `quid_milestone_escrow.wasm` | Multi-milestone escrow programs |
+| `quid-dispute` | `quid_dispute.wasm` | Contested-submission arbitration: timelock + optional arbiter |
 | `hello-world` | `hello_world.wasm` | Scaffold only — safe to ignore |
 
 ## Prerequisites
@@ -36,6 +37,7 @@ Wasm output:
 target/wasm32v1-none/release/quid_store.wasm
 target/wasm32v1-none/release/quid_reputation.wasm
 target/wasm32v1-none/release/quid_milestone_escrow.wasm
+target/wasm32v1-none/release/quid_dispute.wasm
 ```
 
 ## Deploy (testnet)
@@ -53,6 +55,11 @@ stellar contract deploy \
 
 stellar contract deploy \
   --wasm target/wasm32v1-none/release/quid_milestone_escrow.wasm \
+  --source alice \
+  --network testnet
+
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/quid_dispute.wasm \
   --source alice \
   --network testnet
 ```
@@ -105,6 +112,14 @@ See [contracts/quid-reputation/README.md](./contracts/quid-reputation/README.md)
 - `create_program` / `add_milestone` / `approve_milestone` / `cancel_program`
 - getters for program / milestone status
 
+### `quid-dispute`
+
+- `create_dispute` — hunter opens a case, stakes a bond, sets timelock + optional arbiter
+- `stake_bond` — hunter adds to their bond, or respondent posts a counter-bond
+- `resolve_by_arbiter` — named arbiter awards the pot before the deadline
+- `timeout_release` — after the deadline, refund each party's bond
+- Events: `DisputeCreatedEvent`, `BondStakedEvent`, `DisputeResolvedEvent`, `DisputeTimeoutEvent`
+
 ## Tests
 
 ```bash
@@ -113,6 +128,7 @@ cargo test
 cargo test -p quid-store
 cargo test -p quid-reputation
 cargo test -p quid-milestone-escrow
+cargo test -p quid-dispute
 ```
 
 ## Known gaps (good contributor targets)
@@ -121,6 +137,7 @@ cargo test -p quid-milestone-escrow
 - Mission expiry / auto-refund
 - Store → reputation hook on successful payout
 - Align milestone status helpers with production auth rules
+- Wire `quid-dispute` into store reject / payout holds
 - Remove or archive `hello-world`
 
 ## Workspace layout
@@ -132,6 +149,7 @@ quid-contract/
     ├── quid-store/
     ├── quid-reputation/
     ├── quid-milestone-escrow/
+    ├── quid-dispute/
     └── hello-world/
 ```
 

--- a/quid-contract/contracts/quid-dispute/Cargo.toml
+++ b/quid-contract/contracts/quid-dispute/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "quid-dispute"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/quid-contract/contracts/quid-dispute/src/error.rs
+++ b/quid-contract/contracts/quid-dispute/src/error.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum DisputeError {
+    NotAuthorized = 1,
+    InvalidAmount = 2,
+    DisputeNotFound = 3,
+    InvalidState = 4,
+    AlreadyDisputed = 5,
+    TimeoutNotReached = 6,
+    TimeoutReached = 7,
+    NoArbiter = 8,
+    InvalidTimeout = 9,
+    InvalidParties = 10,
+}

--- a/quid-contract/contracts/quid-dispute/src/lib.rs
+++ b/quid-contract/contracts/quid-dispute/src/lib.rs
@@ -1,0 +1,330 @@
+#![no_std]
+use soroban_sdk::{contract, contractevent, contractimpl, token, Address, Env};
+
+mod error;
+mod types;
+
+use error::DisputeError;
+use types::{CreateDisputeParams, DataKey, Dispute, DisputeStatus};
+
+const TTL_LEDGERS: u32 = 5_184_000;
+
+#[contractevent(topics = ["dispute", "created"])]
+pub struct DisputeCreatedEvent {
+    pub dispute_id: u64,
+    pub mission_id: u64,
+    pub hunter: Address,
+    pub respondent: Address,
+}
+
+#[contractevent(topics = ["dispute", "bond"])]
+pub struct BondStakedEvent {
+    pub dispute_id: u64,
+    pub staker: Address,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["dispute", "resolved"])]
+pub struct DisputeResolvedEvent {
+    pub dispute_id: u64,
+    pub winner: Address,
+    pub hunter_wins: bool,
+}
+
+#[contractevent(topics = ["dispute", "timeout"])]
+pub struct DisputeTimeoutEvent {
+    pub dispute_id: u64,
+    pub hunter: Address,
+}
+
+#[contract]
+pub struct QuidDisputeContract;
+
+#[contractimpl]
+impl QuidDisputeContract {
+    /// Open a dispute against a contested submission and stake the hunter bond.
+    /// Optional `arbiter` may later call `resolve_by_arbiter` before the deadline.
+    pub fn create_dispute(
+        env: Env,
+        hunter: Address,
+        params: CreateDisputeParams,
+    ) -> Result<u64, DisputeError> {
+        hunter.require_auth();
+
+        if params.bond_amount <= 0 {
+            return Err(DisputeError::InvalidAmount);
+        }
+        if params.timeout_secs == 0 {
+            return Err(DisputeError::InvalidTimeout);
+        }
+        if hunter == params.respondent {
+            return Err(DisputeError::InvalidParties);
+        }
+        if let Some(ref arbiter) = params.arbiter {
+            if *arbiter == hunter || *arbiter == params.respondent {
+                return Err(DisputeError::InvalidParties);
+            }
+        }
+
+        let open_key = DataKey::OpenDispute(params.mission_id, hunter.clone());
+        if env.storage().persistent().has(&open_key) {
+            return Err(DisputeError::AlreadyDisputed);
+        }
+
+        token::Client::new(&env, &params.bond_token).transfer(
+            &hunter,
+            env.current_contract_address(),
+            &params.bond_amount,
+        );
+
+        let dispute_id = Self::next_dispute_id(&env);
+        let created_at = env.ledger().timestamp();
+        let deadline = created_at
+            .checked_add(params.timeout_secs)
+            .ok_or(DisputeError::InvalidTimeout)?;
+
+        let dispute = Dispute {
+            id: dispute_id,
+            mission_id: params.mission_id,
+            hunter: hunter.clone(),
+            respondent: params.respondent.clone(),
+            arbiter: params.arbiter,
+            bond_token: params.bond_token,
+            hunter_bond: params.bond_amount,
+            respondent_bond: 0,
+            reason_cid: params.reason_cid,
+            created_at,
+            deadline,
+            status: DisputeStatus::Open,
+        };
+
+        Self::store_dispute(&env, &dispute);
+        env.storage().persistent().set(&open_key, &dispute_id);
+        env.storage()
+            .persistent()
+            .extend_ttl(&open_key, TTL_LEDGERS, TTL_LEDGERS);
+
+        DisputeCreatedEvent {
+            dispute_id,
+            mission_id: params.mission_id,
+            hunter,
+            respondent: params.respondent,
+        }
+        .publish(&env);
+
+        BondStakedEvent {
+            dispute_id,
+            staker: dispute.hunter,
+            amount: params.bond_amount,
+        }
+        .publish(&env);
+
+        Ok(dispute_id)
+    }
+
+    /// Stake additional bond as the hunter or a counter-bond as the respondent.
+    pub fn stake_bond(
+        env: Env,
+        dispute_id: u64,
+        staker: Address,
+        amount: i128,
+    ) -> Result<(), DisputeError> {
+        staker.require_auth();
+
+        if amount <= 0 {
+            return Err(DisputeError::InvalidAmount);
+        }
+
+        let mut dispute = Self::get_dispute(env.clone(), dispute_id)?;
+        Self::require_open(&dispute)?;
+        Self::require_before_deadline(&env, &dispute)?;
+
+        if staker == dispute.hunter {
+            dispute.hunter_bond = dispute
+                .hunter_bond
+                .checked_add(amount)
+                .ok_or(DisputeError::InvalidAmount)?;
+        } else if staker == dispute.respondent {
+            dispute.respondent_bond = dispute
+                .respondent_bond
+                .checked_add(amount)
+                .ok_or(DisputeError::InvalidAmount)?;
+        } else {
+            return Err(DisputeError::NotAuthorized);
+        }
+
+        token::Client::new(&env, &dispute.bond_token).transfer(
+            &staker,
+            env.current_contract_address(),
+            &amount,
+        );
+
+        Self::store_dispute(&env, &dispute);
+
+        BondStakedEvent {
+            dispute_id,
+            staker,
+            amount,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Arbiter (if set at create) awards the full bond pot to hunter or respondent.
+    pub fn resolve_by_arbiter(
+        env: Env,
+        dispute_id: u64,
+        arbiter: Address,
+        hunter_wins: bool,
+    ) -> Result<(), DisputeError> {
+        arbiter.require_auth();
+
+        let mut dispute = Self::get_dispute(env.clone(), dispute_id)?;
+        Self::require_open(&dispute)?;
+        Self::require_before_deadline(&env, &dispute)?;
+
+        let named = dispute.arbiter.as_ref().ok_or(DisputeError::NoArbiter)?;
+        if *named != arbiter {
+            return Err(DisputeError::NotAuthorized);
+        }
+
+        let winner = if hunter_wins {
+            dispute.hunter.clone()
+        } else {
+            dispute.respondent.clone()
+        };
+        Self::payout_pot(&env, &dispute, &winner)?;
+
+        dispute.hunter_bond = 0;
+        dispute.respondent_bond = 0;
+        dispute.status = if hunter_wins {
+            DisputeStatus::ResolvedHunter
+        } else {
+            DisputeStatus::ResolvedRespondent
+        };
+
+        Self::clear_open_index(&env, &dispute);
+        Self::store_dispute(&env, &dispute);
+
+        DisputeResolvedEvent {
+            dispute_id,
+            winner,
+            hunter_wins,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// After the timelock, return each party's bond. Anyone may invoke.
+    pub fn timeout_release(env: Env, dispute_id: u64) -> Result<(), DisputeError> {
+        let mut dispute = Self::get_dispute(env.clone(), dispute_id)?;
+        Self::require_open(&dispute)?;
+
+        if env.ledger().timestamp() < dispute.deadline {
+            return Err(DisputeError::TimeoutNotReached);
+        }
+
+        Self::refund_bonds(&env, &dispute)?;
+
+        let hunter = dispute.hunter.clone();
+        dispute.hunter_bond = 0;
+        dispute.respondent_bond = 0;
+        dispute.status = DisputeStatus::TimedOut;
+
+        Self::clear_open_index(&env, &dispute);
+        Self::store_dispute(&env, &dispute);
+
+        DisputeTimeoutEvent { dispute_id, hunter }.publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_dispute(env: Env, dispute_id: u64) -> Result<Dispute, DisputeError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Dispute(dispute_id))
+            .ok_or(DisputeError::DisputeNotFound)
+    }
+
+    pub fn get_dispute_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::DisputeCount)
+            .unwrap_or(0)
+    }
+
+    /// Open dispute id for a (mission, hunter) pair, if any.
+    pub fn get_open_dispute(env: Env, mission_id: u64, hunter: Address) -> Option<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::OpenDispute(mission_id, hunter))
+    }
+
+    fn next_dispute_id(env: &Env) -> u64 {
+        let mut count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DisputeCount)
+            .unwrap_or(0);
+        count += 1;
+        env.storage().instance().set(&DataKey::DisputeCount, &count);
+        count
+    }
+
+    fn store_dispute(env: &Env, dispute: &Dispute) {
+        let key = DataKey::Dispute(dispute.id);
+        env.storage().persistent().set(&key, dispute);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, TTL_LEDGERS, TTL_LEDGERS);
+    }
+
+    fn require_open(dispute: &Dispute) -> Result<(), DisputeError> {
+        if dispute.status != DisputeStatus::Open {
+            return Err(DisputeError::InvalidState);
+        }
+        Ok(())
+    }
+
+    fn require_before_deadline(env: &Env, dispute: &Dispute) -> Result<(), DisputeError> {
+        if env.ledger().timestamp() >= dispute.deadline {
+            return Err(DisputeError::TimeoutReached);
+        }
+        Ok(())
+    }
+
+    fn payout_pot(env: &Env, dispute: &Dispute, winner: &Address) -> Result<(), DisputeError> {
+        let total = dispute
+            .hunter_bond
+            .checked_add(dispute.respondent_bond)
+            .ok_or(DisputeError::InvalidAmount)?;
+        if total > 0 {
+            let contract = env.current_contract_address();
+            token::Client::new(env, &dispute.bond_token).transfer(&contract, winner, &total);
+        }
+        Ok(())
+    }
+
+    fn refund_bonds(env: &Env, dispute: &Dispute) -> Result<(), DisputeError> {
+        let token_client = token::Client::new(env, &dispute.bond_token);
+        let contract = env.current_contract_address();
+        if dispute.hunter_bond > 0 {
+            token_client.transfer(&contract, &dispute.hunter, &dispute.hunter_bond);
+        }
+        if dispute.respondent_bond > 0 {
+            token_client.transfer(&contract, &dispute.respondent, &dispute.respondent_bond);
+        }
+        Ok(())
+    }
+
+    fn clear_open_index(env: &Env, dispute: &Dispute) {
+        env.storage().persistent().remove(&DataKey::OpenDispute(
+            dispute.mission_id,
+            dispute.hunter.clone(),
+        ));
+    }
+}
+
+mod test;

--- a/quid-contract/contracts/quid-dispute/src/test.rs
+++ b/quid-contract/contracts/quid-dispute/src/test.rs
@@ -1,0 +1,476 @@
+#![cfg(test)]
+
+use super::*;
+use crate::types::{CreateDisputeParams, DisputeStatus};
+use soroban_sdk::{
+    testutils::{Address as _, Events as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, String,
+};
+
+fn setup_test_env() -> (Env, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1_000;
+    });
+
+    let contract_id = env.register(QuidDisputeContract, ());
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+
+    (env, contract_id, token_address)
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn params(
+    env: &Env,
+    respondent: &Address,
+    arbiter: Option<Address>,
+    token: &Address,
+    bond: i128,
+    timeout_secs: u64,
+) -> CreateDisputeParams {
+    CreateDisputeParams {
+        mission_id: 1,
+        respondent: respondent.clone(),
+        arbiter,
+        bond_token: token.clone(),
+        bond_amount: bond,
+        reason_cid: String::from_str(env, "QmDisputeReason"),
+        timeout_secs,
+    }
+}
+
+fn open_dispute(
+    env: &Env,
+    client: &QuidDisputeContractClient,
+    token: &Address,
+    hunter_bond: i128,
+    timeout_secs: u64,
+    with_arbiter: bool,
+) -> (Address, Address, Option<Address>, u64) {
+    let hunter = Address::generate(env);
+    let respondent = Address::generate(env);
+    let arbiter = if with_arbiter {
+        Some(Address::generate(env))
+    } else {
+        None
+    };
+    mint(env, token, &hunter, 10_000);
+    mint(env, token, &respondent, 10_000);
+
+    let id = client.create_dispute(
+        &hunter,
+        &params(
+            env,
+            &respondent,
+            arbiter.clone(),
+            token,
+            hunter_bond,
+            timeout_secs,
+        ),
+    );
+    (hunter, respondent, arbiter, id)
+}
+
+#[test]
+fn test_create_dispute_stakes_hunter_bond() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+    let hunter_bond = 100_i128;
+
+    let (hunter, respondent, arbiter, dispute_id) =
+        open_dispute(&env, &client, &token, hunter_bond, 86_400, true);
+
+    assert_eq!(dispute_id, 1);
+    assert_eq!(client.get_dispute_count(), 1);
+    assert_eq!(token_client.balance(&contract_id), hunter_bond);
+    assert_eq!(client.get_open_dispute(&1, &hunter), Some(dispute_id));
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.hunter, hunter);
+    assert_eq!(dispute.respondent, respondent);
+    assert_eq!(dispute.arbiter, arbiter);
+    assert_eq!(dispute.hunter_bond, hunter_bond);
+    assert_eq!(dispute.respondent_bond, 0);
+    assert_eq!(dispute.status, DisputeStatus::Open);
+    assert_eq!(dispute.created_at, 1_000);
+    assert_eq!(dispute.deadline, 1_000 + 86_400);
+}
+
+#[test]
+fn test_stake_bond_respondent_counter() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+    let hunter_bond = 100_i128;
+    let respondent_bond = 150_i128;
+
+    let (_hunter, respondent, _, dispute_id) =
+        open_dispute(&env, &client, &token, hunter_bond, 86_400, true);
+
+    client.stake_bond(&dispute_id, &respondent, &respondent_bond);
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.hunter_bond, hunter_bond);
+    assert_eq!(dispute.respondent_bond, respondent_bond);
+    assert_eq!(
+        token_client.balance(&contract_id),
+        hunter_bond + respondent_bond
+    );
+}
+
+#[test]
+fn test_stake_bond_hunter_can_add() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let extra = 25_i128;
+
+    let (hunter, _, _, dispute_id) = open_dispute(&env, &client, &token, 100, 86_400, false);
+
+    client.stake_bond(&dispute_id, &hunter, &extra);
+    assert_eq!(client.get_dispute(&dispute_id).hunter_bond, 125);
+}
+
+#[test]
+fn test_resolve_by_arbiter_hunter_wins_pot() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+    let hunter_bond = 100_i128;
+    let respondent_bond = 80_i128;
+
+    let (hunter, respondent, arbiter, dispute_id) =
+        open_dispute(&env, &client, &token, hunter_bond, 86_400, true);
+    client.stake_bond(&dispute_id, &respondent, &respondent_bond);
+
+    let hunter_before = token_client.balance(&hunter);
+    client.resolve_by_arbiter(&dispute_id, &arbiter.unwrap(), &true);
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.status, DisputeStatus::ResolvedHunter);
+    assert_eq!(dispute.hunter_bond, 0);
+    assert_eq!(dispute.respondent_bond, 0);
+    assert_eq!(
+        token_client.balance(&hunter),
+        hunter_before + hunter_bond + respondent_bond
+    );
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(client.get_open_dispute(&1, &hunter), None);
+}
+
+#[test]
+fn test_resolve_by_arbiter_respondent_wins_pot() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+    let hunter_bond = 100_i128;
+    let respondent_bond = 80_i128;
+
+    let (_hunter, respondent, arbiter, dispute_id) =
+        open_dispute(&env, &client, &token, hunter_bond, 86_400, true);
+    client.stake_bond(&dispute_id, &respondent, &respondent_bond);
+
+    let respondent_before = token_client.balance(&respondent);
+    client.resolve_by_arbiter(&dispute_id, &arbiter.unwrap(), &false);
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.status, DisputeStatus::ResolvedRespondent);
+    assert_eq!(
+        token_client.balance(&respondent),
+        respondent_before + hunter_bond + respondent_bond
+    );
+}
+
+#[test]
+fn test_timeout_release_refunds_both_bonds() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+    let hunter_bond = 100_i128;
+    let respondent_bond = 60_i128;
+
+    let (hunter, respondent, _, dispute_id) =
+        open_dispute(&env, &client, &token, hunter_bond, 86_400, false);
+    client.stake_bond(&dispute_id, &respondent, &respondent_bond);
+
+    let hunter_before = token_client.balance(&hunter);
+    let respondent_before = token_client.balance(&respondent);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1_000 + 86_400;
+    });
+    client.timeout_release(&dispute_id);
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.status, DisputeStatus::TimedOut);
+    assert_eq!(token_client.balance(&hunter), hunter_before + hunter_bond);
+    assert_eq!(
+        token_client.balance(&respondent),
+        respondent_before + respondent_bond
+    );
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(client.get_open_dispute(&1, &hunter), None);
+}
+
+#[test]
+fn test_timeout_release_hunter_only_bond() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let (hunter, _, _, dispute_id) = open_dispute(&env, &client, &token, 100, 1, false);
+
+    let hunter_before = token_client.balance(&hunter);
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1_001;
+    });
+    client.timeout_release(&dispute_id);
+
+    assert_eq!(token_client.balance(&hunter), hunter_before + 100);
+    assert_eq!(
+        client.get_dispute(&dispute_id).status,
+        DisputeStatus::TimedOut
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_timeout_release_before_deadline() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (_, _, _, dispute_id) = open_dispute(&env, &client, &token, 100, 86_400, false);
+    client.timeout_release(&dispute_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_resolve_after_deadline_fails() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (_, _, arbiter, dispute_id) = open_dispute(&env, &client, &token, 100, 10, true);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1_010;
+    });
+    client.resolve_by_arbiter(&dispute_id, &arbiter.unwrap(), &true);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_resolve_without_arbiter_fails() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (_, _, _, dispute_id) = open_dispute(&env, &client, &token, 100, 86_400, false);
+    let stranger = Address::generate(&env);
+    client.resolve_by_arbiter(&dispute_id, &stranger, &true);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_resolve_wrong_arbiter_fails() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (_, _, _, dispute_id) = open_dispute(&env, &client, &token, 100, 86_400, true);
+    let impostor = Address::generate(&env);
+    client.resolve_by_arbiter(&dispute_id, &impostor, &true);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_stake_bond_unauthorized() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (_, _, _, dispute_id) = open_dispute(&env, &client, &token, 100, 86_400, false);
+    let stranger = Address::generate(&env);
+    mint(&env, &token, &stranger, 1_000);
+    client.stake_bond(&dispute_id, &stranger, &10);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_prevent_duplicate_open_dispute() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (hunter, respondent, _, _) = open_dispute(&env, &client, &token, 100, 86_400, false);
+
+    client.create_dispute(
+        &hunter,
+        &params(&env, &respondent, None, &token, 50, 86_400),
+    );
+}
+
+#[test]
+fn test_new_dispute_allowed_after_timeout() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (hunter, respondent, _, first_id) = open_dispute(&env, &client, &token, 100, 10, false);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1_010;
+    });
+    client.timeout_release(&first_id);
+
+    let second_id = client.create_dispute(
+        &hunter,
+        &params(&env, &respondent, None, &token, 50, 86_400),
+    );
+    assert_eq!(second_id, 2);
+    assert_eq!(client.get_open_dispute(&1, &hunter), Some(2));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_create_dispute_zero_bond() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let hunter = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    client.create_dispute(&hunter, &params(&env, &respondent, None, &token, 0, 86_400));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_create_dispute_zero_timeout() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let hunter = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    mint(&env, &token, &hunter, 1_000);
+    client.create_dispute(&hunter, &params(&env, &respondent, None, &token, 10, 0));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_create_dispute_hunter_is_respondent() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let hunter = Address::generate(&env);
+    mint(&env, &token, &hunter, 1_000);
+    client.create_dispute(&hunter, &params(&env, &hunter, None, &token, 10, 86_400));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_create_dispute_arbiter_is_party() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let hunter = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    mint(&env, &token, &hunter, 1_000);
+    client.create_dispute(
+        &hunter,
+        &params(&env, &respondent, Some(hunter.clone()), &token, 10, 86_400),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_get_dispute_not_found() {
+    let (env, contract_id, _token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let _ = client.get_dispute(&999);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_stake_bond_zero_amount() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (hunter, _, _, dispute_id) = open_dispute(&env, &client, &token, 100, 86_400, false);
+    client.stake_bond(&dispute_id, &hunter, &0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_cannot_resolve_twice() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (_, _, arbiter, dispute_id) = open_dispute(&env, &client, &token, 100, 86_400, true);
+    let arbiter = arbiter.unwrap();
+    client.resolve_by_arbiter(&dispute_id, &arbiter, &true);
+    client.resolve_by_arbiter(&dispute_id, &arbiter, &false);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_cannot_stake_after_resolved() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (hunter, _, arbiter, dispute_id) = open_dispute(&env, &client, &token, 100, 86_400, true);
+    client.resolve_by_arbiter(&dispute_id, &arbiter.unwrap(), &true);
+    client.stake_bond(&dispute_id, &hunter, &10);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_cannot_stake_after_deadline() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let (hunter, _, _, dispute_id) = open_dispute(&env, &client, &token, 100, 10, false);
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1_010;
+    });
+    client.stake_bond(&dispute_id, &hunter, &10);
+}
+
+#[test]
+fn test_happy_path_create_stake_resolve() {
+    let (env, contract_id, token) = setup_test_env();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let hunter = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    mint(&env, &token, &hunter, 1_000);
+    mint(&env, &token, &respondent, 1_000);
+
+    let dispute_id = client.create_dispute(
+        &hunter,
+        &params(&env, &respondent, Some(arbiter.clone()), &token, 40, 86_400),
+    );
+    client.stake_bond(&dispute_id, &respondent, &40);
+
+    let hunter_before = token_client.balance(&hunter);
+    client.resolve_by_arbiter(&dispute_id, &arbiter, &true);
+
+    assert_eq!(
+        client.get_dispute(&dispute_id).status,
+        DisputeStatus::ResolvedHunter
+    );
+    assert_eq!(token_client.balance(&hunter), hunter_before + 80);
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_create_dispute_publishes_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(QuidDisputeContract, ());
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let client = QuidDisputeContractClient::new(&env, &contract_id);
+
+    let hunter = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    mint(&env, &token_address, &hunter, 1_000);
+
+    client.create_dispute(
+        &hunter,
+        &params(&env, &respondent, None, &token_address, 40, 86_400),
+    );
+
+    let events = env.events().all();
+    assert!(events.len() >= 2);
+    assert_eq!(events.last().unwrap().0, contract_id);
+}

--- a/quid-contract/contracts/quid-dispute/src/types.rs
+++ b/quid-contract/contracts/quid-dispute/src/types.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{contracttype, Address, String};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Copy)]
+#[contracttype]
+pub enum DisputeStatus {
+    #[default]
+    Open,
+    ResolvedHunter,
+    ResolvedRespondent,
+    TimedOut,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Dispute {
+    pub id: u64,
+    pub mission_id: u64,
+    pub hunter: Address,
+    pub respondent: Address,
+    pub arbiter: Option<Address>,
+    pub bond_token: Address,
+    pub hunter_bond: i128,
+    pub respondent_bond: i128,
+    pub reason_cid: String,
+    pub created_at: u64,
+    pub deadline: u64,
+    pub status: DisputeStatus,
+}
+
+/// Arguments for opening a dispute. Hunter bond is staked on create.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateDisputeParams {
+    pub mission_id: u64,
+    pub respondent: Address,
+    pub arbiter: Option<Address>,
+    pub bond_token: Address,
+    pub bond_amount: i128,
+    pub reason_cid: String,
+    pub timeout_secs: u64,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Dispute(u64),
+    DisputeCount,
+    /// Maps (mission_id, hunter) → open dispute id.
+    OpenDispute(u64, Address),
+}


### PR DESCRIPTION
## Summary
- Add `quid-dispute` arbitration crate: `create_dispute`, `stake_bond`, `resolve_by_arbiter`, `timeout_release`
- Emit indexer events for create, bond, resolve, and timeout
- Document the contract in the contracts README table

Closes #294

## Test plan
- [ ] `cd quid-contract && cargo test -p quid-dispute`
- [ ] `cd quid-contract && cargo clippy -p quid-dispute --all-targets --all-features -- -D warnings`
- [ ] `cd quid-contract && cargo build -p quid-dispute --target wasm32-unknown-unknown --release`