### PR TITLE
feat(contracts): add quid-referral

### DIFF
--- a/quid-contract/Cargo.lock
+++ b/quid-contract/Cargo.lock
@@ -990,6 +990,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "quid-referral"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "quid-reputation"
 version = "0.1.0"
 dependencies = [

--- a/quid-contract/README.md
+++ b/quid-contract/README.md
@@ -9,6 +9,7 @@ Soroban (Rust) smart contracts for Quid: bounty escrow, reputation, and mileston
 | `quid-store` | `quid_store.wasm` | Mission bounty vault: create, submit, payout, cancel, pause, slash |
 | `quid-reputation` | `quid_reputation.wasm` | Admin, profiles, attestations |
 | `quid-milestone-escrow` | `quid_milestone_escrow.wasm` | Multi-milestone escrow programs |
+| `quid-referral` | `quid_referral.wasm` | Referral attribution + rewards on settled payouts |
 | `hello-world` | `hello_world.wasm` | Scaffold only — safe to ignore |
 
 ## Prerequisites
@@ -36,6 +37,7 @@ Wasm output:
 target/wasm32v1-none/release/quid_store.wasm
 target/wasm32v1-none/release/quid_reputation.wasm
 target/wasm32v1-none/release/quid_milestone_escrow.wasm
+target/wasm32v1-none/release/quid_referral.wasm
 ```
 
 ## Deploy (testnet)
@@ -53,6 +55,11 @@ stellar contract deploy \
 
 stellar contract deploy \
   --wasm target/wasm32v1-none/release/quid_milestone_escrow.wasm \
+  --source alice \
+  --network testnet
+
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/quid_referral.wasm \
   --source alice \
   --network testnet
 ```
@@ -82,6 +89,30 @@ stellar contract invoke \
   get_admin
 ```
 
+### Initialize referrals (once)
+
+```bash
+# 500 bps = 5% of each referred hunter's payout
+stellar contract invoke \
+  --id <REFERRAL_CONTRACT_ID> \
+  --source alice \
+  --network testnet \
+  -- \
+  initialize \
+  --admin alice \
+  --reward_bps 500
+
+# only this address may report payouts
+stellar contract invoke \
+  --id <REFERRAL_CONTRACT_ID> \
+  --source alice \
+  --network testnet \
+  -- \
+  set_payout_hook \
+  --caller alice \
+  --payout_hook <STORE_CONTRACT_ID>
+```
+
 ## Main entrypoints
 
 ### `quid-store`
@@ -100,6 +131,15 @@ stellar contract invoke \
 
 See [contracts/quid-reputation/README.md](./contracts/quid-reputation/README.md).
 
+### `quid-referral`
+
+- `initialize` / `set_reward_bps` / `compute_reward`
+- `register_referral` / `get_referral` / `get_referred_count`
+- `set_payout_hook` / `record_payout` — accrual gated behind a settled payout
+- `fund` / `claim_reward` / `get_claimable` / `get_claimed`
+
+See [contracts/quid-referral/README.md](./contracts/quid-referral/README.md).
+
 ### `quid-milestone-escrow`
 
 - `create_program` / `add_milestone` / `approve_milestone` / `cancel_program`
@@ -113,13 +153,14 @@ cargo test
 cargo test -p quid-store
 cargo test -p quid-reputation
 cargo test -p quid-milestone-escrow
+cargo test -p quid-referral
 ```
 
 ## Known gaps (good contributor targets)
 
 - `reject_submission` + stake refund on `quid-store`
 - Mission expiry / auto-refund
-- Store → reputation hook on successful payout
+- Store → reputation hook on successful payout (also wires `quid-referral.record_payout`)
 - Align milestone status helpers with production auth rules
 - Remove or archive `hello-world`
 
@@ -132,6 +173,7 @@ quid-contract/
     ├── quid-store/
     ├── quid-reputation/
     ├── quid-milestone-escrow/
+    ├── quid-referral/
     └── hello-world/
 ```
 

--- a/quid-contract/contracts/quid-referral/Cargo.toml
+++ b/quid-contract/contracts/quid-referral/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "quid-referral"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/quid-contract/contracts/quid-referral/Makefile
+++ b/quid-contract/contracts/quid-referral/Makefile
@@ -1,0 +1,16 @@
+default: build
+
+all: test
+
+test: build
+	cargo test
+
+build:
+	stellar contract build
+	@ls -l target/wasm32v1-none/release/*.wasm
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/quid-contract/contracts/quid-referral/README.md
+++ b/quid-contract/contracts/quid-referral/README.md
@@ -1,0 +1,103 @@
+# quid-referral
+
+On-chain referral rewards: a referrer earns a cut when a hunter they brought in
+completes a paid mission.
+
+Closes [#301](https://github.com/Quid-proquo/Quid/issues/301).
+
+## Model
+
+Three rules carry the design:
+
+1. **A hunter has exactly one referrer, for life.** The referral record is keyed
+   by the referred address, so attribution can never be overwritten or contested.
+   The referred hunter authorizes the registration, so nobody can be claimed as
+   someone's referral against their will.
+
+2. **Rewards accrue only from a settled payout.** `record_payout` is the single
+   path that grows a claimable balance, and only the configured payout hook —
+   the deployed `quid-store` contract — may call it. There is no way to claim
+   speculatively against a mission that has not paid out.
+
+3. **Rewards are paid from a funded pool, never minted.** `fund` tops the pool
+   up; `claim_reward` refuses rather than half-paying if the pool is short, and
+   the balance stays claimable until it can settle in full.
+
+The referral link lives off-chain. `link_cid` points at it and `link_hash` is
+the on-chain SHA-256 commitment to that CID, so an indexer can match a record to
+its blob without trusting the string it was handed.
+
+## Double-claim prevention
+
+Two distinct replays are blocked, at the storage layer rather than in
+application logic:
+
+| Replay | Guard |
+|--------|-------|
+| Same payout reported twice | `PayoutRecorded(mission_id, referred)` is written before any accrual, and a second report errors with `PayoutAlreadyRecorded` — including when the token is swapped, since the key does not include it |
+| Same balance claimed twice | `claim_reward` zeroes the claimable balance before it transfers, so a re-entrant or repeated claim finds nothing and errors with `NothingToClaim` |
+
+The dedupe slot is claimed even when the hunter has no referrer, so a referral
+registered after a payout cannot be back-paid for it.
+
+## Entrypoints
+
+| Function | Auth | Purpose |
+|----------|------|---------|
+| `initialize(admin, reward_bps)` | `admin` | One-time bootstrap; rejects a second call |
+| `get_admin()` / `set_admin(caller, new_admin)` | — / admin | Ownership |
+| `set_reward_bps(caller, reward_bps)` | admin | Update the rate (`<= 10_000`) |
+| `get_reward_bps()` / `compute_reward(payout_amount)` | — | Current rate; reward owed, rounded down |
+| `set_payout_hook(caller, payout_hook)` | admin | Authorize the reporting contract |
+| `get_payout_hook()` | — | Current hook |
+| `register_referral(referrer, referred, link_cid)` | `referred` | Record attribution + link commitment |
+| `get_referral(referred)` / `has_referral(referred)` | — | Read a record |
+| `get_referred_count(referrer)` | — | How many hunters an address referred |
+| `record_payout(caller, referred, mission_id, token, payout_amount)` | hook | Accrue the referrer's cut; returns the amount (0 if unreferred) |
+| `is_payout_recorded(mission_id, referred)` | — | Dedupe state |
+| `fund(from, token, amount)` | `from` | Top up the reward pool |
+| `get_pool_balance(token)` | — | Pool balance |
+| `claim_reward(referrer, token)` | `referrer` | Pay out everything accrued; returns the amount |
+| `get_claimable` / `get_claimed` | — | Per-referrer, per-token balances |
+
+## Errors
+
+| Code | Variant | When |
+|------|---------|------|
+| 1 | `NotAuthorized` | Caller is not the admin, or not the payout hook |
+| 2 | `AlreadyInitialized` | `initialize` called twice |
+| 3 | `NotInitialized` | Admin read before `initialize` |
+| 4 | `InvalidRewardBps` | Rate above `10_000` |
+| 5 | `InvalidAmount` | Non-positive payout/funding, or negative amount |
+| 6 | `InvalidInput` | Empty `link_cid` |
+| 7 | `SelfReferral` | `referrer == referred` |
+| 8 | `AlreadyRegistered` | Hunter already has a referrer |
+| 9 | `ReferralNotFound` | No record for that hunter |
+| 10 | `PayoutAlreadyRecorded` | This (mission, hunter) payout was already accrued |
+| 11 | `NothingToClaim` | Claimable balance is zero |
+| 12 | `InsufficientFunds` | Pool cannot cover the claim |
+| 13 | `Overflow` | Reward math would overflow `i128` |
+
+## Wiring the payout hook
+
+`quid-store` calling `record_payout` on successful payout is tracked separately
+in [#290](https://github.com/Quid-proquo/Quid/issues/290). This crate ships the
+receiving half so the two can land independently: `record_payout` is written to
+be safe to call for every payout (it returns `0` for unreferred hunters instead
+of failing), and `src/test.rs` exercises it from a stand-in contract to prove
+the cross-contract shape works.
+
+```bash
+stellar contract invoke --id <REFERRAL_ID> --source alice --network testnet \
+  -- set_payout_hook --caller alice --payout_hook <STORE_ID>
+```
+
+## Tests
+
+```bash
+cargo test -p quid-referral
+```
+
+Coverage includes double-claim and double-record prevention, hook
+authorization, self-referral and re-registration, rate-change auth, pool
+underfunding, and per-token accrual isolation.

--- a/quid-contract/contracts/quid-referral/src/error.rs
+++ b/quid-contract/contracts/quid-referral/src/error.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ReferralError {
+    NotAuthorized = 1,
+    AlreadyInitialized = 2,
+    NotInitialized = 3,
+    InvalidRewardBps = 4,
+    InvalidAmount = 5,
+    InvalidInput = 6,
+    SelfReferral = 7,
+    AlreadyRegistered = 8,
+    ReferralNotFound = 9,
+    PayoutAlreadyRecorded = 10,
+    NothingToClaim = 11,
+    InsufficientFunds = 12,
+    Overflow = 13,
+}

--- a/quid-contract/contracts/quid-referral/src/lib.rs
+++ b/quid-contract/contracts/quid-referral/src/lib.rs
@@ -1,0 +1,432 @@
+#![no_std]
+use soroban_sdk::{
+    contract, contractevent, contractimpl, token, xdr::ToXdr, Address, BytesN, Env, String,
+};
+
+mod error;
+mod types;
+
+use error::ReferralError;
+use types::{DataKey, Referral};
+
+/// 100% expressed in basis points.
+pub const MAX_REWARD_BPS: u32 = 10_000;
+
+const RECORD_TTL_LEDGERS: u32 = 5_184_000;
+
+#[contractevent(topics = ["referral", "registered"])]
+pub struct ReferralRegisteredEvent {
+    pub referrer: Address,
+    pub referred: Address,
+    pub link_hash: BytesN<32>,
+}
+
+#[contractevent(topics = ["referral", "accrued"])]
+pub struct RewardAccruedEvent {
+    pub referrer: Address,
+    pub referred: Address,
+    pub mission_id: u64,
+    pub token: Address,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["referral", "claimed"])]
+pub struct RewardClaimedEvent {
+    pub referrer: Address,
+    pub token: Address,
+    pub amount: i128,
+}
+
+#[contractevent(topics = ["referral", "bps"], data_format = "single-value")]
+pub struct RewardBpsUpdatedEvent {
+    pub reward_bps: u32,
+}
+
+/// Referral rewards for founder/hunter acquisition.
+///
+/// A hunter registers who referred them; the referrer only ever accrues a
+/// reward once that hunter is actually paid for a mission, which is reported by
+/// the payout hook (`quid-store`). Rewards are paid from a pool anyone can top
+/// up with `fund`, and are never minted out of thin air.
+#[contract]
+pub struct QuidReferralContract;
+
+#[contractimpl]
+impl QuidReferralContract {
+    // -------------------------------------------------------------------------
+    // Admin bootstrap
+    // -------------------------------------------------------------------------
+
+    pub fn initialize(env: Env, admin: Address, reward_bps: u32) -> Result<(), ReferralError> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(ReferralError::AlreadyInitialized);
+        }
+        if reward_bps > MAX_REWARD_BPS {
+            return Err(ReferralError::InvalidRewardBps);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::RewardBps, &reward_bps);
+        Ok(())
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, ReferralError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(ReferralError::NotInitialized)
+    }
+
+    pub fn set_admin(env: Env, caller: Address, new_admin: Address) -> Result<(), ReferralError> {
+        Self::require_admin(&env, &caller)?;
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Reward rate
+    // -------------------------------------------------------------------------
+
+    /// Set the referral reward rate in basis points. Admin only.
+    ///
+    /// Only affects rewards accrued after the change; already-accrued balances
+    /// stay claimable at the rate they were earned under.
+    pub fn set_reward_bps(env: Env, caller: Address, reward_bps: u32) -> Result<(), ReferralError> {
+        Self::require_admin(&env, &caller)?;
+
+        if reward_bps > MAX_REWARD_BPS {
+            return Err(ReferralError::InvalidRewardBps);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::RewardBps, &reward_bps);
+
+        RewardBpsUpdatedEvent { reward_bps }.publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_reward_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::RewardBps)
+            .unwrap_or(0)
+    }
+
+    /// Reward owed on a payout of `payout_amount`, rounded down.
+    pub fn compute_reward(env: Env, payout_amount: i128) -> Result<i128, ReferralError> {
+        if payout_amount < 0 {
+            return Err(ReferralError::InvalidAmount);
+        }
+
+        let reward_bps = Self::get_reward_bps(env) as i128;
+
+        payout_amount
+            .checked_mul(reward_bps)
+            .map(|scaled| scaled / MAX_REWARD_BPS as i128)
+            .ok_or(ReferralError::Overflow)
+    }
+
+    // -------------------------------------------------------------------------
+    // Payout hook
+    // -------------------------------------------------------------------------
+
+    /// Set the only address allowed to report payouts — in production the
+    /// deployed `quid-store` contract. Admin only.
+    pub fn set_payout_hook(
+        env: Env,
+        caller: Address,
+        payout_hook: Address,
+    ) -> Result<(), ReferralError> {
+        Self::require_admin(&env, &caller)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::PayoutHook, &payout_hook);
+        Ok(())
+    }
+
+    pub fn get_payout_hook(env: Env) -> Result<Address, ReferralError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PayoutHook)
+            .ok_or(ReferralError::NotAuthorized)
+    }
+
+    // -------------------------------------------------------------------------
+    // Registration
+    // -------------------------------------------------------------------------
+
+    /// Record that `referred` arrived through `referrer`'s link.
+    ///
+    /// The referred hunter authorizes, so nobody can be claimed as a referral
+    /// against their will. A hunter can only ever be registered once.
+    pub fn register_referral(
+        env: Env,
+        referrer: Address,
+        referred: Address,
+        link_cid: String,
+    ) -> Result<(), ReferralError> {
+        referred.require_auth();
+
+        if referrer == referred {
+            return Err(ReferralError::SelfReferral);
+        }
+        if link_cid.is_empty() {
+            return Err(ReferralError::InvalidInput);
+        }
+
+        let key = DataKey::Referral(referred.clone());
+        if env.storage().persistent().has(&key) {
+            return Err(ReferralError::AlreadyRegistered);
+        }
+
+        let link_hash = env
+            .crypto()
+            .sha256(&link_cid.clone().to_xdr(&env))
+            .to_bytes();
+
+        let referral = Referral {
+            referrer: referrer.clone(),
+            referred: referred.clone(),
+            link_cid,
+            link_hash: link_hash.clone(),
+            registered_at: env.ledger().timestamp(),
+        };
+
+        env.storage().persistent().set(&key, &referral);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, RECORD_TTL_LEDGERS, RECORD_TTL_LEDGERS);
+
+        let count_key = DataKey::ReferredCount(referrer.clone());
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        env.storage().persistent().set(&count_key, &(count + 1));
+        env.storage()
+            .persistent()
+            .extend_ttl(&count_key, RECORD_TTL_LEDGERS, RECORD_TTL_LEDGERS);
+
+        ReferralRegisteredEvent {
+            referrer,
+            referred,
+            link_hash,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn get_referral(env: Env, referred: Address) -> Result<Referral, ReferralError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Referral(referred))
+            .ok_or(ReferralError::ReferralNotFound)
+    }
+
+    pub fn has_referral(env: Env, referred: Address) -> bool {
+        env.storage().persistent().has(&DataKey::Referral(referred))
+    }
+
+    pub fn get_referred_count(env: Env, referrer: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReferredCount(referrer))
+            .unwrap_or(0)
+    }
+
+    // -------------------------------------------------------------------------
+    // Accrual (payout hook)
+    // -------------------------------------------------------------------------
+
+    /// Report that `referred` was successfully paid `payout_amount` for
+    /// `mission_id`, accruing their referrer's cut.
+    ///
+    /// This is the only path that ever grows a claimable balance, which is what
+    /// makes "reward paid only after successful payout" hold. Callable only by
+    /// the configured payout hook, and only once per (mission, hunter).
+    ///
+    /// Returns the reward accrued — zero when the hunter was never referred, so
+    /// the store can call this for every payout without special-casing.
+    pub fn record_payout(
+        env: Env,
+        caller: Address,
+        referred: Address,
+        mission_id: u64,
+        token: Address,
+        payout_amount: i128,
+    ) -> Result<i128, ReferralError> {
+        caller.require_auth();
+
+        if caller != Self::get_payout_hook(env.clone())? {
+            return Err(ReferralError::NotAuthorized);
+        }
+        if payout_amount <= 0 {
+            return Err(ReferralError::InvalidAmount);
+        }
+
+        let recorded_key = DataKey::PayoutRecorded(mission_id, referred.clone());
+        if env.storage().persistent().has(&recorded_key) {
+            return Err(ReferralError::PayoutAlreadyRecorded);
+        }
+
+        // Claim the (mission, hunter) slot even when there is no referrer, so a
+        // referral registered after the fact cannot be back-paid for it.
+        env.storage().persistent().set(&recorded_key, &true);
+        env.storage().persistent().extend_ttl(
+            &recorded_key,
+            RECORD_TTL_LEDGERS,
+            RECORD_TTL_LEDGERS,
+        );
+
+        let Some(referral) = env
+            .storage()
+            .persistent()
+            .get::<_, Referral>(&DataKey::Referral(referred.clone()))
+        else {
+            return Ok(0);
+        };
+
+        let reward = Self::compute_reward(env.clone(), payout_amount)?;
+        if reward == 0 {
+            return Ok(0);
+        }
+
+        let key = DataKey::Claimable(referral.referrer.clone(), token.clone());
+        let claimable = Self::get_claimable(env.clone(), referral.referrer.clone(), token.clone())
+            .checked_add(reward)
+            .ok_or(ReferralError::Overflow)?;
+        env.storage().persistent().set(&key, &claimable);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, RECORD_TTL_LEDGERS, RECORD_TTL_LEDGERS);
+
+        RewardAccruedEvent {
+            referrer: referral.referrer,
+            referred,
+            mission_id,
+            token,
+            amount: reward,
+        }
+        .publish(&env);
+
+        Ok(reward)
+    }
+
+    pub fn is_payout_recorded(env: Env, mission_id: u64, referred: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::PayoutRecorded(mission_id, referred))
+    }
+
+    // -------------------------------------------------------------------------
+    // Reward pool
+    // -------------------------------------------------------------------------
+
+    /// Top up the pool rewards are paid from.
+    pub fn fund(
+        env: Env,
+        from: Address,
+        token: Address,
+        amount: i128,
+    ) -> Result<(), ReferralError> {
+        from.require_auth();
+
+        if amount <= 0 {
+            return Err(ReferralError::InvalidAmount);
+        }
+
+        token::Client::new(&env, &token).transfer(&from, env.current_contract_address(), &amount);
+
+        Ok(())
+    }
+
+    pub fn get_pool_balance(env: Env, token: Address) -> i128 {
+        token::Client::new(&env, &token).balance(&env.current_contract_address())
+    }
+
+    // -------------------------------------------------------------------------
+    // Claiming
+    // -------------------------------------------------------------------------
+
+    /// Pay out everything `referrer` has accrued in `token`.
+    ///
+    /// The balance is zeroed before the transfer, so a re-entrant claim finds
+    /// nothing left to take.
+    pub fn claim_reward(
+        env: Env,
+        referrer: Address,
+        token: Address,
+    ) -> Result<i128, ReferralError> {
+        referrer.require_auth();
+
+        let amount = Self::get_claimable(env.clone(), referrer.clone(), token.clone());
+        if amount <= 0 {
+            return Err(ReferralError::NothingToClaim);
+        }
+        if Self::get_pool_balance(env.clone(), token.clone()) < amount {
+            return Err(ReferralError::InsufficientFunds);
+        }
+
+        let claimable_key = DataKey::Claimable(referrer.clone(), token.clone());
+        env.storage().persistent().set(&claimable_key, &0i128);
+
+        let claimed_key = DataKey::Claimed(referrer.clone(), token.clone());
+        let claimed = Self::get_claimed(env.clone(), referrer.clone(), token.clone())
+            .checked_add(amount)
+            .ok_or(ReferralError::Overflow)?;
+        env.storage().persistent().set(&claimed_key, &claimed);
+        env.storage()
+            .persistent()
+            .extend_ttl(&claimed_key, RECORD_TTL_LEDGERS, RECORD_TTL_LEDGERS);
+
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &referrer,
+            &amount,
+        );
+
+        RewardClaimedEvent {
+            referrer,
+            token,
+            amount,
+        }
+        .publish(&env);
+
+        Ok(amount)
+    }
+
+    pub fn get_claimable(env: Env, referrer: Address, token: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Claimable(referrer, token))
+            .unwrap_or(0)
+    }
+
+    pub fn get_claimed(env: Env, referrer: Address, token: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Claimed(referrer, token))
+            .unwrap_or(0)
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), ReferralError> {
+        caller.require_auth();
+
+        let admin = Self::get_admin(env.clone())?;
+        if *caller != admin {
+            return Err(ReferralError::NotAuthorized);
+        }
+
+        Ok(())
+    }
+}
+
+mod test;

--- a/quid-contract/contracts/quid-referral/src/test.rs
+++ b/quid-contract/contracts/quid-referral/src/test.rs
@@ -1,0 +1,678 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    contract as test_contract, contractimpl as test_contractimpl,
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, String,
+};
+
+const REWARD_BPS: u32 = 500; // 5%
+const PAYOUT: i128 = 10_000; // reward on this payout: 500
+
+struct Fixture<'a> {
+    env: Env,
+    client: QuidReferralContractClient<'a>,
+    admin: Address,
+    hook: Address,
+    token: Address,
+}
+
+fn setup() -> Fixture<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = QuidReferralContractClient::new(&env, &env.register(QuidReferralContract, ()));
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &REWARD_BPS);
+
+    // A plain address stands in for the deployed quid-store contract.
+    let hook = Address::generate(&env);
+    client.set_payout_hook(&admin, &hook);
+
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    Fixture {
+        env,
+        client,
+        admin,
+        hook,
+        token,
+    }
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+/// Register `referred` under `referrer` and fund the pool so a claim can settle.
+fn referral_ready(f: &Fixture) -> (Address, Address) {
+    let referrer = Address::generate(&f.env);
+    let referred = Address::generate(&f.env);
+
+    f.client.register_referral(
+        &referrer,
+        &referred,
+        &String::from_str(&f.env, "QmReferralLink"),
+    );
+
+    let sponsor = Address::generate(&f.env);
+    mint(&f.env, &f.token, &sponsor, 1_000_000);
+    f.client.fund(&sponsor, &f.token, &1_000_000);
+
+    (referrer, referred)
+}
+
+// -----------------------------------------------------------------------------
+// Bootstrap
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_initialize_sets_admin_and_rate() {
+    let f = setup();
+
+    assert_eq!(f.client.get_admin(), f.admin);
+    assert_eq!(f.client.get_reward_bps(), REWARD_BPS);
+    assert_eq!(f.client.get_payout_hook(), f.hook);
+}
+
+#[test]
+fn test_initialize_twice_fails() {
+    let f = setup();
+    let other = Address::generate(&f.env);
+
+    assert_eq!(
+        f.client.try_initialize(&other, &100),
+        Err(Ok(ReferralError::AlreadyInitialized))
+    );
+}
+
+#[test]
+fn test_initialize_rejects_rate_above_one_hundred_percent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = QuidReferralContractClient::new(&env, &env.register(QuidReferralContract, ()));
+
+    assert_eq!(
+        client.try_initialize(&Address::generate(&env), &(MAX_REWARD_BPS + 1)),
+        Err(Ok(ReferralError::InvalidRewardBps))
+    );
+}
+
+#[test]
+fn test_set_admin_transfers_control() {
+    let f = setup();
+    let new_admin = Address::generate(&f.env);
+
+    f.client.set_admin(&f.admin, &new_admin);
+
+    assert_eq!(f.client.get_admin(), new_admin);
+    assert_eq!(
+        f.client.try_set_reward_bps(&f.admin, &10),
+        Err(Ok(ReferralError::NotAuthorized))
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Reward rate
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_admin_can_update_reward_bps() {
+    let f = setup();
+
+    f.client.set_reward_bps(&f.admin, &1_000);
+
+    assert_eq!(f.client.get_reward_bps(), 1_000);
+}
+
+#[test]
+fn test_non_admin_cannot_update_reward_bps() {
+    let f = setup();
+    let stranger = Address::generate(&f.env);
+
+    assert_eq!(
+        f.client.try_set_reward_bps(&stranger, &0),
+        Err(Ok(ReferralError::NotAuthorized))
+    );
+    assert_eq!(f.client.get_reward_bps(), REWARD_BPS);
+}
+
+#[test]
+fn test_set_reward_bps_rejects_rate_above_one_hundred_percent() {
+    let f = setup();
+
+    assert_eq!(
+        f.client.try_set_reward_bps(&f.admin, &(MAX_REWARD_BPS + 1)),
+        Err(Ok(ReferralError::InvalidRewardBps))
+    );
+    assert_eq!(f.client.get_reward_bps(), REWARD_BPS);
+}
+
+#[test]
+fn test_non_admin_cannot_move_the_payout_hook() {
+    let f = setup();
+    let attacker = Address::generate(&f.env);
+
+    assert_eq!(
+        f.client.try_set_payout_hook(&attacker, &attacker),
+        Err(Ok(ReferralError::NotAuthorized))
+    );
+    assert_eq!(f.client.get_payout_hook(), f.hook);
+}
+
+#[test]
+fn test_compute_reward_math() {
+    let f = setup();
+
+    assert_eq!(f.client.compute_reward(&10_000), 500);
+    assert_eq!(f.client.compute_reward(&0), 0);
+    // Rounds down: 5% of 19 == 0.95
+    assert_eq!(f.client.compute_reward(&19), 0);
+
+    f.client.set_reward_bps(&f.admin, &0);
+    assert_eq!(f.client.compute_reward(&10_000), 0);
+}
+
+#[test]
+fn test_compute_reward_rejects_negative_and_overflow() {
+    let f = setup();
+
+    assert_eq!(
+        f.client.try_compute_reward(&-1),
+        Err(Ok(ReferralError::InvalidAmount))
+    );
+    assert_eq!(
+        f.client.try_compute_reward(&i128::MAX),
+        Err(Ok(ReferralError::Overflow))
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Registration
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_register_referral_records_link_and_hash() {
+    let f = setup();
+    let referrer = Address::generate(&f.env);
+    let referred = Address::generate(&f.env);
+    let cid = String::from_str(&f.env, "QmReferralLink");
+
+    f.client.register_referral(&referrer, &referred, &cid);
+
+    let referral = f.client.get_referral(&referred);
+    assert_eq!(referral.referrer, referrer);
+    assert_eq!(referral.referred, referred);
+    assert_eq!(referral.link_cid, cid);
+    assert_eq!(
+        referral.link_hash,
+        f.env.crypto().sha256(&cid.to_xdr(&f.env)).to_bytes()
+    );
+    assert!(f.client.has_referral(&referred));
+    assert_eq!(f.client.get_referred_count(&referrer), 1);
+}
+
+#[test]
+fn test_a_hunter_can_only_be_referred_once() {
+    let f = setup();
+    let first = Address::generate(&f.env);
+    let second = Address::generate(&f.env);
+    let referred = Address::generate(&f.env);
+    let cid = String::from_str(&f.env, "QmReferralLink");
+
+    f.client.register_referral(&first, &referred, &cid);
+
+    // A second referrer cannot overwrite the attribution.
+    assert_eq!(
+        f.client.try_register_referral(&second, &referred, &cid),
+        Err(Ok(ReferralError::AlreadyRegistered))
+    );
+    assert_eq!(f.client.get_referral(&referred).referrer, first);
+    assert_eq!(f.client.get_referred_count(&second), 0);
+}
+
+#[test]
+fn test_self_referral_is_rejected() {
+    let f = setup();
+    let hunter = Address::generate(&f.env);
+
+    assert_eq!(
+        f.client.try_register_referral(
+            &hunter,
+            &hunter,
+            &String::from_str(&f.env, "QmReferralLink")
+        ),
+        Err(Ok(ReferralError::SelfReferral))
+    );
+}
+
+#[test]
+fn test_empty_link_cid_is_rejected() {
+    let f = setup();
+
+    assert_eq!(
+        f.client.try_register_referral(
+            &Address::generate(&f.env),
+            &Address::generate(&f.env),
+            &String::from_str(&f.env, "")
+        ),
+        Err(Ok(ReferralError::InvalidInput))
+    );
+}
+
+#[test]
+fn test_get_referral_for_unknown_hunter() {
+    let f = setup();
+
+    assert_eq!(
+        f.client.try_get_referral(&Address::generate(&f.env)),
+        Err(Ok(ReferralError::ReferralNotFound))
+    );
+}
+
+#[test]
+fn test_one_referrer_can_refer_many_hunters() {
+    let f = setup();
+    let referrer = Address::generate(&f.env);
+    let cid = String::from_str(&f.env, "QmReferralLink");
+
+    for _ in 0..3 {
+        f.client
+            .register_referral(&referrer, &Address::generate(&f.env), &cid);
+    }
+
+    assert_eq!(f.client.get_referred_count(&referrer), 3);
+}
+
+// -----------------------------------------------------------------------------
+// Accrual is gated behind a successful payout
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_nothing_is_claimable_before_a_payout() {
+    let f = setup();
+    let (referrer, _) = referral_ready(&f);
+
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 0);
+    assert_eq!(
+        f.client.try_claim_reward(&referrer, &f.token),
+        Err(Ok(ReferralError::NothingToClaim))
+    );
+}
+
+#[test]
+fn test_record_payout_accrues_the_referrers_cut() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+
+    let accrued = f
+        .client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+
+    assert_eq!(accrued, 500);
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 500);
+    assert!(f.client.is_payout_recorded(&1, &referred));
+}
+
+#[test]
+fn test_only_the_payout_hook_can_record_a_payout() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+    let attacker = Address::generate(&f.env);
+
+    assert_eq!(
+        f.client
+            .try_record_payout(&attacker, &referred, &1, &f.token, &PAYOUT),
+        Err(Ok(ReferralError::NotAuthorized))
+    );
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 0);
+    assert!(!f.client.is_payout_recorded(&1, &referred));
+}
+
+#[test]
+fn test_record_payout_for_an_unreferred_hunter_is_a_no_op() {
+    let f = setup();
+    let stranger = Address::generate(&f.env);
+
+    assert_eq!(
+        f.client
+            .record_payout(&f.hook, &stranger, &1, &f.token, &PAYOUT),
+        0
+    );
+}
+
+#[test]
+fn test_a_referral_registered_after_a_payout_cannot_be_back_paid() {
+    let f = setup();
+    let referrer = Address::generate(&f.env);
+    let referred = Address::generate(&f.env);
+
+    // Paid first, referral registered afterwards.
+    f.client
+        .record_payout(&f.hook, &referred, &7, &f.token, &PAYOUT);
+    f.client.register_referral(
+        &referrer,
+        &referred,
+        &String::from_str(&f.env, "QmReferralLink"),
+    );
+
+    assert_eq!(
+        f.client
+            .try_record_payout(&f.hook, &referred, &7, &f.token, &PAYOUT),
+        Err(Ok(ReferralError::PayoutAlreadyRecorded))
+    );
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 0);
+}
+
+#[test]
+fn test_record_payout_rejects_non_positive_amounts() {
+    let f = setup();
+    let (_, referred) = referral_ready(&f);
+
+    assert_eq!(
+        f.client
+            .try_record_payout(&f.hook, &referred, &1, &f.token, &0),
+        Err(Ok(ReferralError::InvalidAmount))
+    );
+    assert_eq!(
+        f.client
+            .try_record_payout(&f.hook, &referred, &1, &f.token, &-1),
+        Err(Ok(ReferralError::InvalidAmount))
+    );
+}
+
+#[test]
+fn test_accrual_accumulates_across_missions() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+    f.client
+        .record_payout(&f.hook, &referred, &2, &f.token, &PAYOUT);
+
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 1_000);
+}
+
+#[test]
+fn test_accrual_is_tracked_per_token() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+    let other_token = f
+        .env
+        .register_stellar_asset_contract_v2(Address::generate(&f.env))
+        .address();
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+    f.client
+        .record_payout(&f.hook, &referred, &2, &other_token, &PAYOUT);
+
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 500);
+    assert_eq!(f.client.get_claimable(&referrer, &other_token), 500);
+}
+
+#[test]
+fn test_rate_change_does_not_retroactively_reprice_accrued_rewards() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+    f.client.set_reward_bps(&f.admin, &0);
+    f.client
+        .record_payout(&f.hook, &referred, &2, &f.token, &PAYOUT);
+
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 500);
+}
+
+// -----------------------------------------------------------------------------
+// Double-claim prevention
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_the_same_payout_cannot_be_recorded_twice() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+
+    assert_eq!(
+        f.client
+            .try_record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT),
+        Err(Ok(ReferralError::PayoutAlreadyRecorded))
+    );
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 500);
+}
+
+#[test]
+fn test_replaying_a_payout_in_another_token_does_not_double_pay() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+    let other_token = f
+        .env
+        .register_stellar_asset_contract_v2(Address::generate(&f.env))
+        .address();
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+
+    // The dedupe key is (mission, hunter) — swapping the token does not unlock it.
+    assert_eq!(
+        f.client
+            .try_record_payout(&f.hook, &referred, &1, &other_token, &PAYOUT),
+        Err(Ok(ReferralError::PayoutAlreadyRecorded))
+    );
+    assert_eq!(f.client.get_claimable(&referrer, &other_token), 0);
+}
+
+#[test]
+fn test_claim_pays_once_and_leaves_nothing_behind() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+    let token_client = TokenClient::new(&f.env, &f.token);
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+
+    assert_eq!(f.client.claim_reward(&referrer, &f.token), 500);
+    assert_eq!(token_client.balance(&referrer), 500);
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 0);
+    assert_eq!(f.client.get_claimed(&referrer, &f.token), 500);
+
+    // Second claim finds an empty balance.
+    assert_eq!(
+        f.client.try_claim_reward(&referrer, &f.token),
+        Err(Ok(ReferralError::NothingToClaim))
+    );
+    assert_eq!(token_client.balance(&referrer), 500);
+}
+
+#[test]
+fn test_claiming_again_after_a_new_payout_only_pays_the_new_accrual() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+    let token_client = TokenClient::new(&f.env, &f.token);
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+    f.client.claim_reward(&referrer, &f.token);
+
+    f.client
+        .record_payout(&f.hook, &referred, &2, &f.token, &PAYOUT);
+    assert_eq!(f.client.claim_reward(&referrer, &f.token), 500);
+
+    assert_eq!(token_client.balance(&referrer), 1_000);
+    assert_eq!(f.client.get_claimed(&referrer, &f.token), 1_000);
+}
+
+#[test]
+fn test_one_referrers_balance_is_not_claimable_by_another() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+    let stranger = Address::generate(&f.env);
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+
+    assert_eq!(
+        f.client.try_claim_reward(&stranger, &f.token),
+        Err(Ok(ReferralError::NothingToClaim))
+    );
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 500);
+}
+
+#[test]
+fn test_claim_in_a_token_with_no_accrual() {
+    let f = setup();
+    let (referrer, referred) = referral_ready(&f);
+    let other_token = f
+        .env
+        .register_stellar_asset_contract_v2(Address::generate(&f.env))
+        .address();
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+
+    assert_eq!(
+        f.client.try_claim_reward(&referrer, &other_token),
+        Err(Ok(ReferralError::NothingToClaim))
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Reward pool
+// -----------------------------------------------------------------------------
+
+#[test]
+fn test_claim_fails_when_the_pool_is_short() {
+    let f = setup();
+    let referrer = Address::generate(&f.env);
+    let referred = Address::generate(&f.env);
+    f.client.register_referral(
+        &referrer,
+        &referred,
+        &String::from_str(&f.env, "QmReferralLink"),
+    );
+
+    // Pool holds 100, the accrual is 500.
+    let sponsor = Address::generate(&f.env);
+    mint(&f.env, &f.token, &sponsor, 100);
+    f.client.fund(&sponsor, &f.token, &100);
+
+    f.client
+        .record_payout(&f.hook, &referred, &1, &f.token, &PAYOUT);
+
+    assert_eq!(
+        f.client.try_claim_reward(&referrer, &f.token),
+        Err(Ok(ReferralError::InsufficientFunds))
+    );
+    // The balance survives the failed claim and settles once the pool is topped up.
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 500);
+
+    mint(&f.env, &f.token, &sponsor, 400);
+    f.client.fund(&sponsor, &f.token, &400);
+    assert_eq!(f.client.claim_reward(&referrer, &f.token), 500);
+}
+
+#[test]
+fn test_fund_rejects_non_positive_amounts() {
+    let f = setup();
+    let sponsor = Address::generate(&f.env);
+
+    assert_eq!(
+        f.client.try_fund(&sponsor, &f.token, &0),
+        Err(Ok(ReferralError::InvalidAmount))
+    );
+    assert_eq!(
+        f.client.try_fund(&sponsor, &f.token, &-1),
+        Err(Ok(ReferralError::InvalidAmount))
+    );
+}
+
+#[test]
+fn test_fund_tops_up_the_pool() {
+    let f = setup();
+    let sponsor = Address::generate(&f.env);
+    mint(&f.env, &f.token, &sponsor, 1_000);
+
+    f.client.fund(&sponsor, &f.token, &750);
+
+    assert_eq!(f.client.get_pool_balance(&f.token), 750);
+    assert_eq!(TokenClient::new(&f.env, &f.token).balance(&sponsor), 250);
+}
+
+// -----------------------------------------------------------------------------
+// The hook as another contract calls it
+// -----------------------------------------------------------------------------
+
+/// Stand-in for `quid-store`: reports a payout the way the store will once the
+/// payout hook lands (issue #290).
+#[test_contract]
+pub struct MockStore;
+
+#[test_contractimpl]
+impl MockStore {
+    pub fn pay(
+        env: Env,
+        referral: Address,
+        hunter: Address,
+        mission_id: u64,
+        token: Address,
+        amount: i128,
+    ) -> i128 {
+        QuidReferralContractClient::new(&env, &referral).record_payout(
+            &env.current_contract_address(),
+            &hunter,
+            &mission_id,
+            &token,
+            &amount,
+        )
+    }
+}
+
+#[test]
+fn test_a_contract_hook_can_report_payouts() {
+    let f = setup();
+    let store = f.env.register(MockStore, ());
+    f.client.set_payout_hook(&f.admin, &store);
+
+    let (referrer, referred) = referral_ready(&f);
+
+    let accrued = MockStoreClient::new(&f.env, &store).pay(
+        &f.client.address,
+        &referred,
+        &1,
+        &f.token,
+        &PAYOUT,
+    );
+
+    assert_eq!(accrued, 500);
+    assert_eq!(f.client.get_claimable(&referrer, &f.token), 500);
+    assert_eq!(f.client.claim_reward(&referrer, &f.token), 500);
+}
+
+#[test]
+fn test_a_contract_that_is_not_the_hook_cannot_report_payouts() {
+    let f = setup();
+    let rogue = f.env.register(MockStore, ());
+    let (_, referred) = referral_ready(&f);
+
+    let result = MockStoreClient::new(&f.env, &rogue).try_pay(
+        &f.client.address,
+        &referred,
+        &1,
+        &f.token,
+        &PAYOUT,
+    );
+
+    // The referral contract rejects it, which unwinds the calling contract too.
+    assert!(result.is_err());
+    assert!(!f.client.is_payout_recorded(&1, &referred));
+}

--- a/quid-contract/contracts/quid-referral/src/types.rs
+++ b/quid-contract/contracts/quid-referral/src/types.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::{contracttype, Address, BytesN, String};
+
+/// A hunter's one and only referral record.
+///
+/// The link itself lives off-chain; `link_cid` points at it and `link_hash` is
+/// the on-chain commitment to that CID, so an indexer can match a record to its
+/// blob without trusting the string it was handed.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Referral {
+    pub referrer: Address,
+    pub referred: Address,
+    pub link_cid: String,
+    pub link_hash: BytesN<32>,
+    pub registered_at: u64,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    /// Referral reward rate in basis points (1 bps = 0.01%).
+    RewardBps,
+    /// The only address allowed to report successful payouts.
+    PayoutHook,
+    /// Referral record, keyed by the referred hunter so a hunter has exactly
+    /// one referrer for life.
+    Referral(Address),
+    /// How many hunters an address has referred.
+    ReferredCount(Address),
+    /// Unclaimed reward for a referrer in one token.
+    Claimable(Address, Address),
+    /// Lifetime claimed reward for a referrer in one token.
+    Claimed(Address, Address),
+    /// Marks a (mission, hunter) payout as already accrued.
+    PayoutRecorded(u64, Address),
+}


### PR DESCRIPTION
Closes #301

On-chain referral rewards: a referrer earns a cut when a hunter they brought in completes a paid mission.

## Model

Three rules carry the design:

1. **A hunter has exactly one referrer, for life.** The record is keyed by the referred address, so attribution can never be overwritten or contested. The referred hunter authorizes the registration, so nobody can be claimed as someone's referral against their will. Self-referral and empty CIDs are rejected.

2. **Rewards accrue only from a settled payout.** `record_payout` is the single path that grows a claimable balance, and only the configured payout hook may call it. There is no way to claim speculatively against a mission that has not paid out.

3. **Rewards pay from a funded pool, never minted.** `fund` tops it up; `claim_reward` refuses rather than half-paying if the pool is short, and the balance stays claimable until it can settle in full.

The referral link lives off-chain: `link_cid` points at it and `link_hash` is the on-chain SHA-256 commitment to that CID, so an indexer can match a record to its blob without trusting the string it was handed.

## Double-claim prevention

Both replays are blocked at the storage layer rather than in application logic:

| Replay | Guard |
|--------|-------|
| Same payout reported twice | `PayoutRecorded(mission_id, referred)` is written before any accrual; a second report errors with `PayoutAlreadyRecorded`, including when the token is swapped, since the key does not include it |
| Same balance claimed twice | `claim_reward` zeroes the claimable balance before it transfers, so a re-entrant or repeated claim finds nothing and errors with `NothingToClaim` |

The dedupe slot is claimed even when the hunter has no referrer, so a referral registered after a payout cannot be back-paid for it.

## On the stated dependency

This issue lists the quid-store → quid-reputation payout hook (#290) as a dependency; that issue is still open. So this PR ships only the receiving half and does not touch `quid-store`, which keeps it independently reviewable and mergeable in either order.

`record_payout` is written to be safe to call for every payout — it returns `0` for unreferred hunters instead of failing — so wiring it in alongside the reputation attestation is a one-line addition. `src/test.rs` exercises it from a stand-in contract to prove the cross-contract shape works.

## Acceptance criteria

- [x] Referral link recorded on-chain or via CID + on-chain hash — `link_cid` plus SHA-256 `link_hash`
- [x] Reward paid only after successful payout — accrual is reachable only through the hook-gated `record_payout`
- [x] Tests for double-claim prevention

## Tests

`cargo test -p quid-referral` — 36 tests covering: double-record (same mission, and across tokens), double-claim, claim-before-payout, back-pay of a late registration, hook authorization from both an address and a stand-in contract, non-admin rate/hook changes, self-referral and re-registration, reward math (rounding, 0%, negative, i128 overflow), per-token accrual isolation, rate changes not repricing accrued balances, and pool underfunding.

CI steps run locally and green: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --target wasm32-unknown-unknown --release`, `stellar contract build`, `cargo test`.
